### PR TITLE
Remove ADC Init Configs

### DIFF
--- a/src/edgepi/adc/edgepi_adc.py
+++ b/src/edgepi/adc/edgepi_adc.py
@@ -103,7 +103,7 @@ class EdgePiADC(SPI):
         self.set_adc_reference(ADCReferenceSwitching.GND_SW1.value)
         # TODO: get gain, offset, ref configs from the config module
 
-    def reapply_config(self):
+    def __reapply_config(self):
         """
         Restore ADC to custom EdgePi configuration
         """
@@ -348,7 +348,7 @@ class EdgePiADC(SPI):
         application of custom power-on configurations required by EdgePi.
         """
         self.transfer(self.adc_ops.reset_adc())
-        self.reapply_config()
+        self.__reapply_config()
 
     def __is_data_ready(self):
         # pylint: disable=unused-private-member

--- a/src/test_edgepi/integration_tests/test_adc/test_adc.py
+++ b/src/test_edgepi/integration_tests/test_adc/test_adc.py
@@ -26,7 +26,7 @@ from edgepi.adc.edgepi_adc import EdgePiADC
 @pytest.fixture(name="adc", scope="module")
 def fixture_adc():
     adc = EdgePiADC()
-    adc.reapply_config()
+    adc._EdgePiADC__reapply_config()
     yield adc
 
 


### PR DESCRIPTION
Removed configuration from ADC init, refactored to `reapply_config` method for user to call manually.