### PR TITLE
generate_calib_param dictionary added

### DIFF
--- a/src/edgepi/calibration/edgepi_calibration.py
+++ b/src/edgepi/calibration/edgepi_calibration.py
@@ -4,11 +4,7 @@ able to generate new calibration parameters using measurements tools.
 '''
 
 from edgepi.calibration.eeprom_constants import ModuleNames
-from edgepi.calibration.calibration_constants import(
-    NumOfCh,
-    CalibParam,
-    # ReferenceV
-)
+from edgepi.calibration.calibration_constants import NumOfCh
 
 
 class EdgePiCalibration():
@@ -28,28 +24,6 @@ class EdgePiCalibration():
         self.num_of_ch = NumOfCh[module.name].value
         self.full_scale_range = None
         self.full_scale_code = None
-
-    def generate_calib_params_dict(self, calib_parms: list = None):
-        '''
-        Function to generate dictionary of calibration parameters
-        Args:
-            calib_param (list): The list contains the calibration parameter of each channel packed
-                                in 1-D array. The gain and offset values are repeated increment of 2
-                                index number. Refer to the following example:
-                                [gain_ch1, offset_ch1, ... gain_ch_n, offset_ch_n]
-                                index: [0, 1, 2, 3, ... ,2*(n-1), 2*(n-1)+1], n = number of channel
-        Return:
-            ch_to_calib_dict (dict): dictionary mapped channel to CalibParam data class
-            ie) {1 : CalibParam(gain, offset)
-                 .
-                 .
-                 .
-                 nth_channel : CalibParam(gain, offset)}
-        '''
-        ch_to_calib_dict = {}
-        for ch in range(self.num_of_ch):
-            ch_to_calib_dict[ch] = CalibParam(gain=calib_parms[ch*2], offset=calib_parms[ch*2+1])
-        return ch_to_calib_dict
 
     def generate_measurements_dict(self, num_of_points: int = None):
         '''

--- a/src/edgepi/calibration/edgepi_eeprom.py
+++ b/src/edgepi/calibration/edgepi_eeprom.py
@@ -99,10 +99,10 @@ class EdgePiEEPROM(I2CDevice):
         # pylint: disable=no-member
         self.eeprom_layout.ParseFromString(self.__read_edgepi_reserved_memory())
         eeprom_data = EdgePiEEPROMData()
-        eeprom_data.dac_calib_parms=eeprom_data.message_to_list(self.eeprom_layout.dac)
-        eeprom_data.adc_calib_parms=eeprom_data.message_to_list(self.eeprom_layout.adc)
-        eeprom_data.rtd_calib_parms=eeprom_data.message_to_list(self.eeprom_layout.rtd)
-        eeprom_data.tc_calib_parms=eeprom_data.message_to_list(self.eeprom_layout.tc)
+        eeprom_data.dac_calib_parms=eeprom_data.message_to_dict(self.eeprom_layout.dac)
+        eeprom_data.adc_calib_parms=eeprom_data.message_to_dict(self.eeprom_layout.adc)
+        eeprom_data.rtd_calib_parms=eeprom_data.message_to_dict(self.eeprom_layout.rtd)
+        eeprom_data.tc_calib_parms=eeprom_data.message_to_dict(self.eeprom_layout.tc)
         eeprom_data.config_key=eeprom_data.keys_to_str(self.eeprom_layout.config_key)
         eeprom_data.data_key=eeprom_data.keys_to_str(self.eeprom_layout.data_key)
         eeprom_data.serial= self.eeprom_layout.serial_number

--- a/src/edgepi/calibration/eeprom_constants.py
+++ b/src/edgepi/calibration/eeprom_constants.py
@@ -3,6 +3,7 @@
 from enum import Enum
 from dataclasses import dataclass
 from edgepi.calibration.eeprom_mapping_pb2 import EepromLayout
+from edgepi.calibration.calibration_constants import CalibParam
 
 class EEPROMInfo(Enum):
     """
@@ -76,7 +77,7 @@ class EdgePiEEPROMData:
     model: str = None
     client_id: str = None
 
-    def message_to_list(self, data_to_unpack: EepromLayout = None):
+    def message_to_dict(self, data_to_unpack: EepromLayout = None):
         """
         Function to unpack message to list
         Args:
@@ -84,11 +85,11 @@ class EdgePiEEPROMData:
         Returns:
             calib_list: 1-D array
         """
-        calib_list=[]
-        for ch in data_to_unpack.calibs:
-            calib_list.append(ch.gain)
-            calib_list.append(ch.offset)
-        return calib_list
+        calib_dict={}
+        for indx, ch in enumerate(data_to_unpack.calibs):
+            calib_dict[indx] = CalibParam(gain=ch.gain,
+                                        offset=ch.offset)
+        return calib_dict
 
     def keys_to_str(self, data_to_unpack: EepromLayout = None):
         """

--- a/src/edgepi/dac/edgepi_dac.py
+++ b/src/edgepi/dac/edgepi_dac.py
@@ -21,11 +21,6 @@ from edgepi.peripherals.spi import SpiDevice as spi
 from edgepi.gpio.edgepi_gpio import EdgePiGPIO
 from edgepi.gpio.gpio_configs import GpioConfigs
 from edgepi.calibration.edgepi_eeprom import EdgePiEEPROM
-from edgepi.calibration.eeprom_constants import ModuleNames
-from edgepi.calibration.edgepi_calibration import EdgePiCalibration
-
-
-
 
 class EdgePiDAC(spi):
     """A EdgePi DAC device"""
@@ -61,11 +56,10 @@ class EdgePiDAC(spi):
 
         # Read edgepi reserved data and generate calibration parameter dictionary
         eeprom = EdgePiEEPROM()
-        calib = EdgePiCalibration(ModuleNames.DAC)
         eeprom_data  = eeprom.get_edgepi_reserved_data()
-        calib_dict = calib.generate_calib_params_dict(eeprom_data .dac_calib_parms)
+        dac_calib_params = eeprom_data.dac_calib_parms
 
-        self.dac_ops = DACCommands(calib_dict)
+        self.dac_ops = DACCommands(dac_calib_params)
         self.gpio = EdgePiGPIO(GpioConfigs.DAC.value)
 
         self.__dac_power_state = {

--- a/src/test_edgepi/unit_tests/test_calibration/test_eeprom_constants.py
+++ b/src/test_edgepi/unit_tests/test_calibration/test_eeprom_constants.py
@@ -20,19 +20,19 @@ def test_edgepi_eeprom_data():
     memory_map = EepromLayout()
     memory_map.ParseFromString(read_binfile())
     eeprom_data = EdgePiEEPROMData()
-    eeprom_data.dac_calib_parms=eeprom_data.message_to_list(memory_map.dac)
-    eeprom_data.adc_calib_parms=eeprom_data.message_to_list(memory_map.adc)
-    eeprom_data.rtd_calib_parms=eeprom_data.message_to_list(memory_map.rtd)
-    eeprom_data.tc_calib_parms=eeprom_data.message_to_list(memory_map.tc)
+    eeprom_data.dac_calib_parms=eeprom_data.message_to_dict(memory_map.dac)
+    eeprom_data.adc_calib_parms=eeprom_data.message_to_dict(memory_map.adc)
+    eeprom_data.rtd_calib_parms=eeprom_data.message_to_dict(memory_map.rtd)
+    eeprom_data.tc_calib_parms=eeprom_data.message_to_dict(memory_map.tc)
     eeprom_data.config_key=eeprom_data.keys_to_str(memory_map.config_key)
     eeprom_data.data_key=eeprom_data.keys_to_str(memory_map.data_key)
     eeprom_data.serial=memory_map.serial_number
     eeprom_data.model=memory_map.model
     eeprom_data.client_id=memory_map.client_id
-    assert eeprom_data.dac_calib_parms == eeprom_data.message_to_list(memory_map.dac)
-    assert eeprom_data.adc_calib_parms==eeprom_data.message_to_list(memory_map.adc)
-    assert eeprom_data.rtd_calib_parms==eeprom_data.message_to_list(memory_map.rtd)
-    assert eeprom_data.tc_calib_parms==eeprom_data.message_to_list(memory_map.tc)
+    assert eeprom_data.dac_calib_parms == eeprom_data.message_to_dict(memory_map.dac)
+    assert eeprom_data.adc_calib_parms==eeprom_data.message_to_dict(memory_map.adc)
+    assert eeprom_data.rtd_calib_parms==eeprom_data.message_to_dict(memory_map.rtd)
+    assert eeprom_data.tc_calib_parms==eeprom_data.message_to_dict(memory_map.tc)
     assert eeprom_data.config_key.certificate == memory_map.config_key.certificate
     assert eeprom_data.config_key.private == memory_map.config_key.private_key
     assert eeprom_data.data_key.certificate == memory_map.data_key.certificate

--- a/src/test_edgepi/unit_tests/test_dac/test_edgepi_dac.py
+++ b/src/test_edgepi/unit_tests/test_dac/test_edgepi_dac.py
@@ -20,22 +20,23 @@ from edgepi.dac.dac_constants import (
 )
 from edgepi.dac.edgepi_dac import EdgePiDAC
 from edgepi.calibration.eeprom_constants import EdgePiEEPROMData
+from edgepi.calibration.calibration_constants import CalibParam
 
-dummy_calib_param_list = [1,0,
-                          1,0,
-                          1,0,
-                          1,0,
-                          1,0,
-                          1,0,
-                          1,0,
-                          1,0,]
+dummy_calib_param_dict = {0:CalibParam(gain=1,offset=0),
+                          1:CalibParam(gain=1,offset=0),
+                          2:CalibParam(gain=1,offset=0),
+                          3:CalibParam(gain=1,offset=0),
+                          4:CalibParam(gain=1,offset=0),
+                          5:CalibParam(gain=1,offset=0),
+                          6:CalibParam(gain=1,offset=0),
+                          7:CalibParam(gain=1,offset=0)}
 
 @pytest.fixture(name="dac")
 def fixture_test_dac(mocker):
     mocker.patch("edgepi.peripherals.spi.SPI")
     mocker.patch("edgepi.dac.edgepi_dac.EdgePiGPIO")
     mocker.patch("edgepi.dac.edgepi_dac.EdgePiEEPROM.get_edgepi_reserved_data",
-                  return_value = EdgePiEEPROMData(dac_calib_parms=dummy_calib_param_list))
+                  return_value = EdgePiEEPROMData(dac_calib_parms=dummy_calib_param_dict))
     yield EdgePiDAC()
 
 @pytest.fixture(name="dac_mock_periph")
@@ -43,7 +44,7 @@ def fixture_test_dac_write_voltage(mocker):
     mocker.patch("edgepi.peripherals.spi.SPI")
     mocker.patch("edgepi.peripherals.i2c.I2C")
     mocker.patch("edgepi.dac.edgepi_dac.EdgePiEEPROM.get_edgepi_reserved_data",
-                  return_value = EdgePiEEPROMData(dac_calib_parms=dummy_calib_param_list))
+                  return_value = EdgePiEEPROMData(dac_calib_parms=dummy_calib_param_dict))
     yield EdgePiDAC()
 
 
@@ -179,7 +180,7 @@ def test_dac_send_to_gpio_pins(mocker, analog_out, pin_name, voltage, mock_name)
     mock_set = mocker.patch("edgepi.dac.edgepi_dac.EdgePiGPIO.set_expander_pin")
     mock_clear = mocker.patch("edgepi.dac.edgepi_dac.EdgePiGPIO.clear_expander_pin")
     mocker.patch("edgepi.dac.edgepi_dac.EdgePiEEPROM.get_edgepi_reserved_data",
-                  return_value = EdgePiEEPROMData(dac_calib_parms=dummy_calib_param_list))
+                  return_value = EdgePiEEPROMData(dac_calib_parms=dummy_calib_param_dict))
     dac = EdgePiDAC()
     dac._EdgePiDAC__send_to_gpio_pins(analog_out, voltage)
     # check correct clause is entered depending on voltage written
@@ -231,14 +232,12 @@ def test_enable_dac_gain(mocker, enable, result, mocker_values):
     mocker.patch("edgepi.peripherals.spi.SPI")
     mocker.patch("edgepi.peripherals.i2c.I2C")
     mocker.patch("edgepi.gpio.edgepi_gpio.I2CDevice")
-    mocker.patch("edgepi.dac.edgepi_dac.EdgePiEEPROM.sequential_read",
-                  return_value = dummy_calib_param_list)
     mocker.patch("edgepi.dac.edgepi_dac.EdgePiDAC.get_state",
                   return_value = (mocker_values[0], mocker_values[1], mocker_values[2]))
     set_dac_gain = mocker.patch("edgepi.dac.edgepi_dac.EdgePiGPIO.set_expander_pin")
     clear_dac_gain = mocker.patch("edgepi.dac.edgepi_dac.EdgePiGPIO.clear_expander_pin")
     mocker.patch("edgepi.dac.edgepi_dac.EdgePiEEPROM.get_edgepi_reserved_data",
-                  return_value = EdgePiEEPROMData(dac_calib_parms=dummy_calib_param_list))
+                  return_value = EdgePiEEPROMData(dac_calib_parms=dummy_calib_param_dict))
     dac = EdgePiDAC()
     # pylint: disable=expression-not-assigned
     assert dac.enable_dac_gain(enable) == result
@@ -261,7 +260,7 @@ def test_get_state(mocker, analog_out, code, voltage, gain, result, mock_val):
     mocker.patch("edgepi.dac.edgepi_dac.EdgePiGPIO.get_pin_direction", return_value = mock_val[3])
     mocker.patch("edgepi.peripherals.spi.SpiDevice.transfer", return_value=mock_val[0:3])
     mocker.patch("edgepi.dac.edgepi_dac.EdgePiEEPROM.get_edgepi_reserved_data",
-                  return_value = EdgePiEEPROMData(dac_calib_parms=dummy_calib_param_list))
+                  return_value = EdgePiEEPROMData(dac_calib_parms=dummy_calib_param_dict))
     dac = EdgePiDAC()
     code_val, voltage_val, gain_state = dac.get_state(analog_out, code, voltage, gain)
     assert code_val == result[0]


### PR DESCRIPTION
closes #111 

Importing of calibration data from the EEPROM implemented. During the module instantiation, the EEPROM and calibration class will load and generate a dictionary of calibration data class. The data class, then, is used during code2voltage or voltage2code calculation.
