### PR TITLE
Get State Override Cache

### DIFF
--- a/src/edgepi/adc/edgepi_adc.py
+++ b/src/edgepi/adc/edgepi_adc.py
@@ -987,6 +987,9 @@ class EdgePiADC(SPI):
         """
         Read the current hardware state of configurable ADC properties
 
+        Args:
+            `override_cache` (bool): force SPI read to get hardware state
+
         Returns:
             ADCState: information about the current ADC hardware state
         """


### PR DESCRIPTION
Closes #174 

Changes were needed to allow edgepi modules to force SPI read for get_state operations, such as during ADC sequential reading.