### PR TITLE
Add Build Dependencies

### DIFF
--- a/.github/workflows/build-and-publish-TestPyPI.yml
+++ b/.github/workflows/build-and-publish-TestPyPI.yml
@@ -34,6 +34,14 @@ jobs:
         commit_email: bot@edgepi.com
         login: bot-edgepi
         token: "${{ secrets.ACTIONS_BOT_TOKEN }}"
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.10'
+    - name: Install Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        if [ -f requirements_build.txt ]; then python -m pip install -r requirements_build.txt; fi
     - name: Build Package
       run: |
         python -m build


### PR DESCRIPTION
Add deleted build dependencies back to TestPyPi publishing workflow (accidentally removed during #192)