### PR TITLE
Update Dev Package Version

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,3 +1,3 @@
 [bumpversion]
 tag_name = "rc/v{new_version}"
-current_version = 1.1.9
+current_version = 1.1.10

--- a/.github/workflows/update-dev-version.yml
+++ b/.github/workflows/update-dev-version.yml
@@ -6,7 +6,7 @@ name: Merge Staging to Dev
 on:
   push:
    branches:
-    - test-branch
+    - update-dev-version
     # workflow_run:
     #   workflows: ["CI build"]
     #   types:

--- a/.github/workflows/update-dev-version.yml
+++ b/.github/workflows/update-dev-version.yml
@@ -1,0 +1,42 @@
+# This workflow will merge staging to dev, on push to staging, in order
+# to apply auto bumped package version on staging to dev
+
+name: Merge Staging to Dev
+
+on:
+  push:
+   branches:
+    - test-branch
+    # workflow_run:
+    #   workflows: ["CI build"]
+    #   types:
+    #     - completed
+    #   branches: [staging]
+
+jobs:
+  # on-success:
+  merge-branches:
+    name: Merge Staging to Dev
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      # with:
+      #     token: ${{ secrets.ACTIONS_BOT_TOKEN }}
+    - name: Merge Staging to Dev
+      uses: devmasx/merge-branch@master
+      with:
+          type: now
+          from_branch: update-dev-version
+          target_branch: test-branch
+          github_token: ${{ secrets.ACTIONS_BOT_TOKEN }}
+      # env:
+      #   commit_name: bot-edgepi
+      #   commit_email: bot@edgepi.com
+      #   username: bot-edgepi
+      # run: |
+      #   git config user.name ${{ env.commit_name }}
+      #   git config user.email ${{ env.commit_email }}
+      #   git checkout origin dev
+      #   git merge --squash origin staging -m "apply bumped package version"
+      #   git push origin dev

--- a/.github/workflows/update-dev-version.yml
+++ b/.github/workflows/update-dev-version.yml
@@ -1,42 +1,27 @@
-# This workflow will merge staging to dev, on push to staging, in order
+# This workflow will merge staging to dev, on auto-bump completed, in order
 # to apply auto bumped package version on staging to dev
 
 name: Merge Staging to Dev
 
 on:
-  push:
-   branches:
-    - update-dev-version
-    # workflow_run:
-    #   workflows: ["CI build"]
-    #   types:
-    #     - completed
-    #   branches: [staging]
+  workflow_run:
+    workflows: ["Build and Publish to TestPyPI"]
+    types:
+      - completed
+    branches: [staging]
 
 jobs:
-  # on-success:
-  merge-branches:
+  on-success:
     name: Merge Staging to Dev
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-      # with:
-      #     token: ${{ secrets.ACTIONS_BOT_TOKEN }}
     - name: Merge Staging to Dev
       uses: devmasx/merge-branch@master
       with:
           type: now
-          from_branch: update-dev-version
-          target_branch: test-branch
+          from_branch: staging
+          target_branch: dev
           github_token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      # env:
-      #   commit_name: bot-edgepi
-      #   commit_email: bot@edgepi.com
-      #   username: bot-edgepi
-      # run: |
-      #   git config user.name ${{ env.commit_name }}
-      #   git config user.email ${{ env.commit_email }}
-      #   git checkout origin dev
-      #   git merge --squash origin staging -m "apply bumped package version"
-      #   git push origin dev
+          message: "apply auto bumped package version"

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as file:
 
 setuptools.setup(
     name="edgepi-python-sdk",
-    version="1.1.9",
+    version="1.1.10",
     author="S.Park",
     author_email="spark@osensa.com",
     description="EdgePi Python SDK package",


### PR DESCRIPTION
Added workflow to merge staging to dev on successful auto-bump and publish run on staging, in order to keep package version synchronized on both branches