### PR TITLE
re-remove merge action

### DIFF
--- a/.github/workflows/build-and-publish-TestPyPI.yml
+++ b/.github/workflows/build-and-publish-TestPyPI.yml
@@ -34,14 +34,6 @@ jobs:
         commit_email: bot@edgepi.com
         login: bot-edgepi
         token: "${{ secrets.ACTIONS_BOT_TOKEN }}"
-    - name: Merge Staging to Dev
-      uses: devmasx/merge-branch@master
-      with:
-          type: now
-          from_branch: staging
-          target_branch: dev
-          github_token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-          message: "apply auto bumped package version"
     - name: Set up Python
       uses: actions/setup-python@v3
       with:


### PR DESCRIPTION
I forgot to update `dev` package version before opening the pr to `staging`, and during merge conflict resolution the broken merge action was re-added to our workflow on `dev`. Deleting it again.