### PR TITLE
Digital_output module issue fix

### DIFF
--- a/src/edgepi/digital_output/README.md
+++ b/src/edgepi/digital_output/README.md
@@ -11,24 +11,35 @@ from edgepi.digital_output.edgepi_digital_output import EdgePiDigitalOutput
 
 digital_output = EdgePiDigitalOutput()
 
-pin_1_state = digital_output.digital_output_direction(GpioPins.DIN1, True)
-pin_2_state = digital_output.digital_output_direction(GpioPins.DIN2, True)
-pin_3_state = digital_output.digital_output_direction(GpioPins.DIN3, True)
-pin_4_state = digital_output.digital_output_direction(GpioPins.DIN4, True)
-pin_5_state = digital_output.digital_output_direction(GpioPins.DIN5, True)
-pin_6_state = digital_output.digital_output_direction(GpioPins.DIN6, True)
-pin_7_state = digital_output.digital_output_direction(GpioPins.DIN7, True)
-pin_8_state = digital_output.digital_output_direction(GpioPins.DIN8, True)
+# setting corresponding GpioPin to Output direction
+digital_output.digital_output_direction(GpioPins.DOUT1, False)
+digital_output.digital_output_direction(GpioPins.DOUT2, False)
+digital_output.digital_output_direction(GpioPins.DOUT3, False)
+digital_output.digital_output_direction(GpioPins.DOUT4, False)
+digital_output.digital_output_direction(GpioPins.DOUT5, False)
+digital_output.digital_output_direction(GpioPins.DOUT6, False)
+digital_output.digital_output_direction(GpioPins.DOUT7, False)
+digital_output.digital_output_direction(GpioPins.DOUT8, False)
 
-pin_1_state = digital_output.digital_output_state(GpioPins.DIN1, True)
-pin_2_state = digital_output.digital_output_state(GpioPins.DIN2, True)
-pin_3_state = digital_output.digital_output_state(GpioPins.DIN3, True)
-pin_4_state = digital_output.digital_output_state(GpioPins.DIN4, True)
-pin_5_state = digital_output.digital_output_state(GpioPins.DIN5, True)
-pin_6_state = digital_output.digital_output_state(GpioPins.DIN6, True)
-pin_7_state = digital_output.digital_output_state(GpioPins.DIN7, True)
-pin_8_state = digital_output.digital_output_state(GpioPins.DIN8, True)
+# setting corresponding GpioPin to output High/On
+digital_output.digital_output_state(GpioPins.DOUT1, True)
+digital_output.digital_output_state(GpioPins.DOUT2, True)
+digital_output.digital_output_state(GpioPins.DOUT3, True)
+digital_output.digital_output_state(GpioPins.DOUT4, True)
+digital_output.digital_output_state(GpioPins.DOUT5, True)
+digital_output.digital_output_state(GpioPins.DOUT6, True)
+digital_output.digital_output_state(GpioPins.DOUT7, True)
+digital_output.digital_output_state(GpioPins.DOUT8, True)
 
+# setting corresponding GpioPin to output Low/Off
+digital_output.digital_output_state(GpioPins.DOUT1, False)
+digital_output.digital_output_state(GpioPins.DOUT2, False)
+digital_output.digital_output_state(GpioPins.DOUT3, False)
+digital_output.digital_output_state(GpioPins.DOUT4, False)
+digital_output.digital_output_state(GpioPins.DOUT5, False)
+digital_output.digital_output_state(GpioPins.DOUT6, False)
+digital_output.digital_output_state(GpioPins.DOUT7, False)
+digital_output.digital_output_state(GpioPins.DOUT8, False)
 ```
 
 
@@ -36,10 +47,22 @@ pin_8_state = digital_output.digital_output_state(GpioPins.DIN8, True)
 
 ```python
     def digital_output_state(self, pin_name: GpioPins = None, state: bool = None)
+        """
+        change the output state of the pin to the state passed as argument
+        Args:
+            pin_name (GpioPins): GpioPin enums
+            state (bool): True = output high, False, output low
+        """
 ```
 Take `pin_name` and `state` as a parameter and sets the output state of the corresponding pin with the state passed.
 ```python
     def digital_output_direction(self, pin_name: GpioPins = None, direction: bool = None):
+        """
+        change the output state of the pin to the state passed as argument
+        Args:
+            pin_name (GpioPins): GpioPin enums
+            state (bool): True = direction input, False = direction output
+        """
 ```
 Take `pin_name` and `direction` as a parameter and sets the direction of the corresponding pin with the state passed.
 

--- a/src/edgepi/gpio/edgepi_gpio_chip.py
+++ b/src/edgepi/gpio/edgepi_gpio_chip.py
@@ -44,7 +44,7 @@ class EdgePiGPIOChip(GpioDevice):
                        pin_dir=self.gpiochip_pins_dict[pin_name].dir,
                        pin_bias=self.gpiochip_pins_dict[pin_name].bias)
         state = self.read_state()
-        self.close()
+        self.close_gpio()
         return state
 
     def write_gpio_pin_state(self, pin_name: str = None, state: bool = None):
@@ -61,7 +61,7 @@ class EdgePiGPIOChip(GpioDevice):
                        pin_bias=self.gpiochip_pins_dict[pin_name].bias)
         self.write_state(state)
         read_back = self.read_state()
-        self.close()
+        self.close_gpio()
         return read_back
 
     def set_gpio_pin_dir(self, pin_name: str = None, direction: bool = None):
@@ -74,7 +74,7 @@ class EdgePiGPIOChip(GpioDevice):
         self.open_gpio(pin_num=self.__pin_name_dict[pin_name],
                        pin_dir="in" if direction else "out",
                        pin_bias=self.gpiochip_pins_dict[pin_name].bias)
-        self.close()
+        self.close_gpio()
 
     def toggle_gpio_pin_state(self, pin_name: str = None):
         """
@@ -92,4 +92,4 @@ class EdgePiGPIOChip(GpioDevice):
             self.write_state(False)
         else:
             self.write_state(True)
-        self.close()
+        self.close_gpio()

--- a/src/edgepi/gpio/edgepi_gpio_expander.py
+++ b/src/edgepi/gpio/edgepi_gpio_expander.py
@@ -112,6 +112,7 @@ class EdgePiGPIOExpander(I2CDevice):
         reg_addx = dir_out_code.reg_address
 
         # get register value of port this pin belongs to
+        print(f'reg_addx {reg_addx}, dev_address {dev_address}')
         reg_val = self.__read_register(reg_addx, dev_address)
 
         # set pin to low before setting to output (hazard)

--- a/src/edgepi/gpio/edgepi_gpio_expander.py
+++ b/src/edgepi/gpio/edgepi_gpio_expander.py
@@ -112,7 +112,6 @@ class EdgePiGPIOExpander(I2CDevice):
         reg_addx = dir_out_code.reg_address
 
         # get register value of port this pin belongs to
-        print(f'reg_addx {reg_addx}, dev_address {dev_address}')
         reg_val = self.__read_register(reg_addx, dev_address)
 
         # set pin to low before setting to output (hazard)

--- a/src/edgepi/gpio/gpio_configs.py
+++ b/src/edgepi/gpio/gpio_configs.py
@@ -232,6 +232,7 @@ _list_of_DOUT_cpu_gpios =  [
 ]
 
 _list_of_DOUT_expander_gpios =[
+    None, None,
     DOUTPins.DOUT8.value, DOUTPins.DOUT7.value,
     DOUTPins.DOUT6.value, DOUTPins.DOUT5.value,
     DOUTPins.DOUT4.value, DOUTPins.DOUT3.value]
@@ -349,7 +350,8 @@ def _generate_DOUT_expander_pins(): #pylint: disable=C0103
     pin_dict = {}
     for pin, set_code, clear_code, dir_out_code, dir_in_code in \
     zip(_list_of_DOUT_expander_gpios,GpioAOutputSet,GpioAOutputClear,GpioAPinDirOut,GpioAPinDirIn):
-
+        if pin is None:
+            continue
         pin_dict.update({pin : I2cPinInfo(set_code.value,
                                           clear_code.value,
                                           dir_out_code.value,

--- a/src/edgepi/peripherals/gpio.py
+++ b/src/edgepi/peripherals/gpio.py
@@ -43,6 +43,6 @@ class GpioDevice:
         """
         self.gpio.write(state)
 
-    def close(self):
+    def close_gpio(self):
         """Close GPIO connection"""
         self.gpio.close()

--- a/src/test_edgepi/unit_tests/test_gpio/test_edgpepi_gpio_chip.py
+++ b/src/test_edgepi/unit_tests/test_gpio/test_edgpepi_gpio_chip.py
@@ -24,7 +24,7 @@ def test_edgepi_gpio_init():
 @pytest.mark.parametrize("pin_name, mock_value, result", [("DIN1",[True], True)])
 def test_read_gpio_pin_state(mocker, pin_name, mock_value, result):
     mocker.patch("edgepi.peripherals.gpio.GpioDevice.open_gpio")
-    mocker.patch("edgepi.peripherals.gpio.GpioDevice.close")
+    mocker.patch("edgepi.peripherals.gpio.GpioDevice.close_gpio")
     mocker.patch("edgepi.peripherals.gpio.GpioDevice.read_state", return_value = mock_value[0])
     gpio = EdgePiGPIOChip()
     assert gpio.read_gpio_pin_state(pin_name) == result
@@ -33,7 +33,7 @@ def test_read_gpio_pin_state(mocker, pin_name, mock_value, result):
                                                           ("DIN1",[False], False)])
 def test_write_gpio_pin_state(mocker, pin_name, mock_value, result):
     mocker.patch("edgepi.peripherals.gpio.GpioDevice.open_gpio")
-    mocker.patch("edgepi.peripherals.gpio.GpioDevice.close")
+    mocker.patch("edgepi.peripherals.gpio.GpioDevice.close_gpio")
     mocker.patch("edgepi.peripherals.gpio.GpioDevice.write_state")
     mocker.patch("edgepi.peripherals.gpio.GpioDevice.read_state", return_value = mock_value[0])
     gpio = EdgePiGPIOChip()


### PR DESCRIPTION
Close #224 , Close #223 , Close #222 

- fixes GPIOError caused by OSError for reading gpiochip0 device file
- README file edited for example code and clear instruction
- Correct LED lit up when corresponding digital output is set to high