### PR TITLE
Dev digital io integration test

### DIFF
--- a/tests/hardware_tests/test_digital_io.py
+++ b/tests/hardware_tests/test_digital_io.py
@@ -1,0 +1,28 @@
+'''Hardware tests for verifying digital input and output module'''
+
+import pytest
+from edgepi.digital_input.edgepi_digital_input import EdgePiDigitalInput
+from edgepi.digital_output.edgepi_digital_output import EdgePiDigitalOutput
+from edgepi.gpio.gpio_constants import GpioPins
+
+@pytest.mark.parametrize("din, dout", [
+    (GpioPins.DIN1, GpioPins.DOUT1),
+    (GpioPins.DIN2, GpioPins.DOUT2),
+    (GpioPins.DIN3, GpioPins.DOUT3),
+    (GpioPins.DIN4, GpioPins.DOUT4),
+    (GpioPins.DIN5, GpioPins.DOUT5),
+    (GpioPins.DIN6, GpioPins.DOUT6),
+    (GpioPins.DIN7, GpioPins.DOUT7),
+    (GpioPins.DIN8, GpioPins.DOUT8),
+])
+def test_input_state(pin_name):
+    din=EdgePiDigitalInput()
+    dout = EdgePiDigitalOutput()
+    initial_state = din.digital_input_state(pin_name)
+    dout.digital_output_state(pin_name, True)
+    changed_state = din.digital_input_state(pin_name)
+    assert initial_state is not changed_state
+    dout.digital_output_state(pin_name, True)
+    changed_state = din.digital_input_state(pin_name)
+    assert initial_state is changed_state
+    

--- a/tests/hardware_tests/test_digital_io.py
+++ b/tests/hardware_tests/test_digital_io.py
@@ -22,7 +22,7 @@ def test_input_state(din_pin, dout_pin):
     dout.digital_output_state(dout_pin, True)
     changed_state = din.digital_input_state(din_pin)
     assert initial_state is not changed_state
-    dout.digital_output_state(dout_pin, True)
+    dout.digital_output_state(dout_pin, False)
     changed_state = din.digital_input_state(din_pin)
     assert initial_state is changed_state
     

--- a/tests/hardware_tests/test_digital_io.py
+++ b/tests/hardware_tests/test_digital_io.py
@@ -1,5 +1,6 @@
 '''Hardware tests for verifying digital input and output module'''
 
+from time import sleep
 import pytest
 from edgepi.digital_input.edgepi_digital_input import EdgePiDigitalInput
 from edgepi.digital_output.edgepi_digital_output import EdgePiDigitalOutput
@@ -20,9 +21,11 @@ def test_input_state(din_pin, dout_pin):
     dout = EdgePiDigitalOutput()
     initial_state = din.digital_input_state(din_pin)
     dout.digital_output_state(dout_pin, True)
+    sleep(0.1)
     changed_state = din.digital_input_state(din_pin)
     assert initial_state is not changed_state
     dout.digital_output_state(dout_pin, False)
+    sleep(0.1)
     changed_state = din.digital_input_state(din_pin)
     assert initial_state is changed_state
     

--- a/tests/hardware_tests/test_digital_io.py
+++ b/tests/hardware_tests/test_digital_io.py
@@ -5,7 +5,7 @@ from edgepi.digital_input.edgepi_digital_input import EdgePiDigitalInput
 from edgepi.digital_output.edgepi_digital_output import EdgePiDigitalOutput
 from edgepi.gpio.gpio_constants import GpioPins
 
-@pytest.mark.parametrize("din, dout", [
+@pytest.mark.parametrize("din_pin, dout_pin", [
     (GpioPins.DIN1, GpioPins.DOUT1),
     (GpioPins.DIN2, GpioPins.DOUT2),
     (GpioPins.DIN3, GpioPins.DOUT3),
@@ -15,14 +15,14 @@ from edgepi.gpio.gpio_constants import GpioPins
     (GpioPins.DIN7, GpioPins.DOUT7),
     (GpioPins.DIN8, GpioPins.DOUT8),
 ])
-def test_input_state(pin_name):
+def test_input_state(din_pin, dout_pin):
     din=EdgePiDigitalInput()
     dout = EdgePiDigitalOutput()
-    initial_state = din.digital_input_state(pin_name)
-    dout.digital_output_state(pin_name, True)
-    changed_state = din.digital_input_state(pin_name)
+    initial_state = din.digital_input_state(din_pin)
+    dout.digital_output_state(dout_pin, True)
+    changed_state = din.digital_input_state(din_pin)
     assert initial_state is not changed_state
-    dout.digital_output_state(pin_name, True)
-    changed_state = din.digital_input_state(pin_name)
+    dout.digital_output_state(dout_pin, True)
+    changed_state = din.digital_input_state(din_pin)
     assert initial_state is changed_state
     

--- a/tests/integration_tests/test_digital_in/test_digital_in.py
+++ b/tests/integration_tests/test_digital_in/test_digital_in.py
@@ -17,5 +17,5 @@ from edgepi.gpio.gpio_constants import GpioPins
 def test_input_state(pin_name):
     din=EdgePiDigitalInput()
     pin_state = din.digital_input_state(pin_name)
-    assert pin_state == False
+    assert pin_state is False
     

--- a/tests/integration_tests/test_digital_in/test_digital_in.py
+++ b/tests/integration_tests/test_digital_in/test_digital_in.py
@@ -14,7 +14,7 @@ from edgepi.gpio.gpio_constants import GpioPins
     (GpioPins.DIN7),
     (GpioPins.DIN8),
 ])
-def test_output_high(pin_name):
+def test_input_state(pin_name):
     din=EdgePiDigitalInput()
     pin_state = din.digital_input_state(pin_name)
     assert pin_state == False

--- a/tests/integration_tests/test_digital_in/test_digital_in.py
+++ b/tests/integration_tests/test_digital_in/test_digital_in.py
@@ -1,0 +1,21 @@
+'''Integration tests for edgepi_digital_input.py module'''
+
+import pytest
+from edgepi.digital_input.edgepi_digital_input import EdgePiDigitalInput
+from edgepi.gpio.gpio_constants import GpioPins
+
+@pytest.mark.parametrize("pin_name", [
+    (GpioPins.DIN1),
+    (GpioPins.DIN2),
+    (GpioPins.DIN3),
+    (GpioPins.DIN4),
+    (GpioPins.DIN5),
+    (GpioPins.DIN6),
+    (GpioPins.DIN7),
+    (GpioPins.DIN8),
+])
+def test_output_high(pin_name):
+    din=EdgePiDigitalInput()
+    pin_state = din.digital_input_state(pin_name)
+    assert pin_state == False
+    


### PR DESCRIPTION
close #229 
- digital input integration test added
   - simply checks the corresponding input channel 
- digital input and output hardware test added 
   - changes output and input channels are tied together, read the input state while toggling the output channel 