### PR TITLE
Dev dac integration test

### DIFF
--- a/tests/hardware_tests/test_voltage_rw.py
+++ b/tests/hardware_tests/test_voltage_rw.py
@@ -13,7 +13,7 @@ from edgepi.dac.dac_constants import DACChannel
 _logger = logging.getLogger(__name__)
 
 
-NUM_CHANNELS = 1
+NUM_CHANNELS = 8
 READS_PER_WRITE = 1
 RW_ERROR = 1e-3 # TODO: change to mV
 MAX_VOLTAGE = 5.0

--- a/tests/hardware_tests/test_voltage_rw.py
+++ b/tests/hardware_tests/test_voltage_rw.py
@@ -2,6 +2,7 @@
 
 import logging
 
+from time import sleep
 import pytest
 from edgepi.adc.edgepi_adc import EdgePiADC
 from edgepi.adc.adc_constants import ADCChannel, ADCNum, DiffMode
@@ -17,6 +18,7 @@ READS_PER_WRITE = 1
 RW_ERROR = 1e-1 # TODO: change to mV
 MAX_VOLTAGE = 5.0
 VOLTAGE_STEP = 0.1
+WRITE_READ_DELAY = 0.1
 
 
 _ch_map = {
@@ -71,7 +73,7 @@ def _measure_voltage_individual(
     ):
     # write to DAC channel
     dac.write_voltage(dac_ch, write_voltage)
-
+    sleep(WRITE_READ_DELAY)
     for _ in range(READS_PER_WRITE):
         read_voltage = adc.read_voltage(adc_num)
         _logger.info(_voltage_rw_msg(dac_ch, write_voltage, read_voltage))

--- a/tests/hardware_tests/test_voltage_rw.py
+++ b/tests/hardware_tests/test_voltage_rw.py
@@ -15,9 +15,9 @@ _logger = logging.getLogger(__name__)
 
 NUM_CHANNELS = 1
 READS_PER_WRITE = 1
-RW_ERROR = 1e-1 # TODO: change to mV
+RW_ERROR = 1e-3 # TODO: change to mV
 MAX_VOLTAGE = 5.0
-VOLTAGE_STEP = 0.1
+VOLTAGE_STEP = 0.01
 WRITE_READ_DELAY = 0.1
 
 

--- a/tests/hardware_tests/test_voltage_rw.py
+++ b/tests/hardware_tests/test_voltage_rw.py
@@ -12,7 +12,7 @@ from edgepi.dac.dac_constants import DACChannel
 _logger = logging.getLogger(__name__)
 
 
-NUM_CHANNELS = 8
+NUM_CHANNELS = 1
 READS_PER_WRITE = 1
 RW_ERROR = 1e-1 # TODO: change to mV
 MAX_VOLTAGE = 5.0

--- a/tests/integration_tests/test_dac/test_dac.py
+++ b/tests/integration_tests/test_dac/test_dac.py
@@ -98,4 +98,4 @@ def test_dac_reset(dac):
         # pylint: disable=line-too-long
         assert dac.compute_expected_voltage(ch) == pytest.approx(dac.dac_ops.dict_calib_param[ch.value].offset , abs=STORE_ERROR)
         # pylint: disable=line-too-long
-        assert not dac.gpio.expander_pin_dict[dac._EdgePiDAC__analog_out_pin_map[ch.value].value].is_high
+        assert dac.gpio.expander_pin_dict[dac._EdgePiDAC__analog_out_pin_map[ch.value].value].is_high

--- a/tests/integration_tests/test_dac/test_dac.py
+++ b/tests/integration_tests/test_dac/test_dac.py
@@ -18,6 +18,7 @@ UPPER_VOLT_LIMIT = UPPER_LIMIT  # upper code limit with 3 dec place precision
 LOWER_VOLT_LIMIT = 0  # lower code limit
 NUM_PINS = 8
 FLOAT_ERROR = 1e-3
+STORE_ERROR = 1e-9
 
 
 @pytest.fixture(name="dac")
@@ -95,6 +96,6 @@ def test_dac_reset(dac):
 
     for ch in CH:
         # pylint: disable=line-too-long
-        assert dac.compute_expected_voltage(ch) == pytest.approx(dac.dac_ops.dict_calib_param[ch.value] , abs=FLOAT_ERROR)
+        assert dac.compute_expected_voltage(ch) == pytest.approx(dac.dac_ops.dict_calib_param[ch.value].offset , abs=STORE_ERROR)
         # pylint: disable=line-too-long
         assert not dac.gpio.expander_pin_dict[dac._EdgePiDAC__analog_out_pin_map[ch.value].value].is_high

--- a/tests/integration_tests/test_dac/test_dac.py
+++ b/tests/integration_tests/test_dac/test_dac.py
@@ -95,6 +95,6 @@ def test_dac_reset(dac):
 
     for ch in CH:
         # pylint: disable=line-too-long
-        assert dac.compute_expected_voltage(ch) == pytest.approx(dac.dac_ops.dict_calib_param[ch] , abs=FLOAT_ERROR)
+        assert dac.compute_expected_voltage(ch) == pytest.approx(dac.dac_ops.dict_calib_param[ch.value] , abs=FLOAT_ERROR)
         # pylint: disable=line-too-long
         assert not dac.gpio.expander_pin_dict[dac._EdgePiDAC__analog_out_pin_map[ch.value].value].is_high

--- a/tests/integration_tests/test_dac/test_dac.py
+++ b/tests/integration_tests/test_dac/test_dac.py
@@ -94,6 +94,7 @@ def test_dac_reset(dac):
     dac.reset()
 
     for ch in CH:
-        assert dac.compute_expected_voltage(ch) == pytest.approx(0, abs=FLOAT_ERROR)
+        # pylint: disable=line-too-long
+        assert dac.compute_expected_voltage(ch) == pytest.approx(dac.dac_ops.dict_calib_param[ch] , abs=FLOAT_ERROR)
         # pylint: disable=line-too-long
         assert not dac.gpio.expander_pin_dict[dac._EdgePiDAC__analog_out_pin_map[ch.value].value].is_high


### PR DESCRIPTION
- DAC integration test issue was resolved by comparing the proper value
   - when DAC resets, the code value resets to 0. As a result, the resulting code_2_voltage value is equal to the offset 
- when _measure_voltage_individual() is called, it writes and reads voltage. Sometimes reading happens before the voltage settles to the target. Added 10ms delay. 

The image below shows the test passing with 10mV step size with 0.001mV error window.

![image](https://user-images.githubusercontent.com/78987042/210912846-9387febb-c23c-4943-bf4d-8a73fd282a19.png)
