### PR TITLE
Dev dac refactor

### DIFF
--- a/src/edgepi/dac/README.md
+++ b/src/edgepi/dac/README.md
@@ -29,11 +29,72 @@ edgepi_dac.reset()
 ## Using DAC Module
 This section introduces DAC functionality available to users, and provides a guide on how to interact with the DAC module.
 
-1. Writing Voltage to Analog Out Pins
-    - Write a voltage value to be sent through an analog output pin
-3. Reading Voltage from Analog Out Pins
-    - Read voltage from DAC channel corresponding to an analog out pin
-4. Setting Power Mode Analog Out Pins
-    - Each analog out pin can be configured to operate in lower power consumption modes.
-5. Resetting DAC
-    - Performs a software reset of the DAC, returning all settings and values to the default power-on state.
+1. setting output voltage range
+
+```python
+    def enable_dac_gain(self, enable: bool = None, ch_code_handler: bool = False):
+        """
+        Enable/Disable internal DAC gain by toggling the DAC_GAIN pin
+        Args:
+            enable (bool): enable boolean to set or clear the gpio pin
+            ch_code_handler (bool): flag to re-write code value of each channel to keep the same
+                                    output voltage
+        Return:
+            gain_state (bool): state of the gain pin
+        """
+```
+
+2. set output voltage
+
+```python
+    def write_voltage(self, analog_out: DACChannel, voltage: float):
+        """
+        Write a voltage value to an analog out pin. Voltage will be continuously
+        transmitted to the analog out pin until a 0 V value is written to it.
+
+        Args:
+            `analog_out` (DACChannel): A/D_OUT pin to write a voltage value to.
+
+            `voltage` (float): the voltage value to write, in volts.
+
+        Raises:
+            `ValueError`: if voltage has more decimal places than DAC accuracy limit
+        """
+```
+
+3. reading channel state 
+
+```python
+    def get_state(self, analog_out: DACChannel = None,
+                        code: bool = None,
+                        voltage: bool = None,
+                        gain: bool = None):
+        """
+        the method returns the state of requested parameters. It will either read the register of
+        DAC or GPIO expander to retrieve the current state.
+
+        Args:
+            analog_out (DACChannel): channel number of interest
+            code (bool): requesting the current code value written in the specified channel input
+                         register
+            voltage (bool): requesting the current expected voltage at the terminal block pin
+            gian (bool): requesting the current gain value set for the DAC
+        Returns:
+            code_val (int): code value read from the input register, None when not requested
+            voltage_val (float): voltage calculated using the code value, None when not requested
+            gain_state (bool): true if dac gain is enabled or False disabled, None when not
+                               requested
+        """
+```
+
+4. Resetting DAC to power-on reset state
+
+```python
+    def reset(self):
+        """
+        Performs a software reset of the EdgePi DAC to power-on default values,
+        and stops all voltage transmissions through pins.
+        """
+        cmd = self.dac_ops.combine_command(COM.COM_SW_RESET.value, NULL_BITS, SW_RESET)
+        self.transfer(cmd)
+```

--- a/src/edgepi/dac/README.md
+++ b/src/edgepi/dac/README.md
@@ -6,7 +6,8 @@ This section will demonstrate how to import the EdgePi DAC module, and use it wr
 Note, the EdgePi has eight analog out pins, indexed from 1 to 8.
 
 ### Writing Voltage to Analog Out Pin
-```
+```python
+from edgepi.dac.dac_constants import DACChannel as Ch
 from edgepi.dac.edgepi_dac import EdgePiDAC
 
 # initialize DAC

--- a/src/edgepi/dac/README.md
+++ b/src/edgepi/dac/README.md
@@ -13,11 +13,17 @@ from edgepi.dac.edgepi_dac import EdgePiDAC
 # initialize DAC
 edgepi_dac = EdgePiDAC()
 
-# write voltage value of 3.3 V to analog out pin number 1
-edgepi_dac.write_voltage(1, 3.3)
+# setting DAC range 0-5V
+edgepi_dac.enable_dac_gain(False)
 
-# read last voltage written to pin number 1
-edgepi_dac.read_voltage(1)
+# write voltage value of 3.3 V to analog out pin number 1
+edgepi_dac.write_voltage(Ch.AOUT1, 3.3)
+
+# read state of DAC output 1
+code, voltage, gain = edgepi_dac.get_state(Ch.AOUT1, True, True, True)
+
+# Resets the DAC to power-on reset state
+edgepi_dac.reset()
 ```
 ---
 ## Using DAC Module

--- a/src/edgepi/dac/dac_commands.py
+++ b/src/edgepi/dac/dac_commands.py
@@ -23,8 +23,8 @@ class DACCommands:
 
     def generate_write_and_update_command(self, ch: int, data: int) -> list:
         """Construct a write and update command"""
-        self.check_range(ch, 0, len(CH))
-        self.check_range(data, 0, CALIB_CONSTS.RANGE.value)
+        self.check_range(ch, 0, NUM_PINS-1)
+        self.check_range(data, 0, CALIB_CONSTS.RANGE.value-1)
         return self.combine_command(COMMAND.COM_WRITE_UPDATE.value, CH(ch).value, data)
 
     def __voltage_to_float_code(self, ch: int, expected: float, dac_gain: int = 1):
@@ -50,7 +50,7 @@ class DACCommands:
             int: 16 bit binary code value for writing voltage value to DAC
         """
         # DAC channels are 0 indexed
-        self.check_range(ch, 0, NUM_PINS)
+        self.check_range(ch, 0, NUM_PINS-1)
         float_code = self.__voltage_to_float_code(ch, expected, dac_gain)
         _logger.debug(f"Int code generated {int(float_code)}")
         # DAC only accepts int values, round to nearest int
@@ -139,7 +139,7 @@ class DACCommands:
     @staticmethod
     def check_range(target, range_min, range_max) -> bool:
         """Validates target is in range between a min and max value"""
-        if range_min <= target < range_max:
+        if range_min <= target <= range_max:
             return True
 
         raise ValueError(f"Target {target} is out of range ")

--- a/src/edgepi/dac/dac_commands.py
+++ b/src/edgepi/dac/dac_commands.py
@@ -50,7 +50,7 @@ class DACCommands:
             int: 16 bit binary code value for writing voltage value to DAC
         """
         # DAC channels are 0 indexed
-        self.check_range(ch, 0, NUM_PINS - 1)
+        self.check_range(ch, 0, NUM_PINS)
         float_code = self.__voltage_to_float_code(ch, expected, dac_gain)
         _logger.debug(f"Int code generated {int(float_code)}")
         # DAC only accepts int values, round to nearest int
@@ -139,7 +139,7 @@ class DACCommands:
     @staticmethod
     def check_range(target, range_min, range_max) -> bool:
         """Validates target is in range between a min and max value"""
-        if range_min <= target <= range_max:
+        if range_min <= target < range_max:
             return True
 
         raise ValueError(f"Target {target} is out of range ")

--- a/src/edgepi/dac/dac_constants.py
+++ b/src/edgepi/dac/dac_constants.py
@@ -8,7 +8,7 @@ DAC_PRECISION = 3  # decimal place precision for voltage conversions
 SW_RESET = 0x1234  # software reset command data bits
 NULL_BITS = 0x0
 READ_WRITE_SIZE = 3  # size of DAC read/write in bytes
-UPPER_LIMIT = 5.000 # upper limit for voltage writes to DAC
+UPPER_LIMIT = 5.0005 # upper limit for voltage writes to DAC
 
 
 class EdgePiDacCom(Enum):

--- a/src/edgepi/dac/dac_constants.py
+++ b/src/edgepi/dac/dac_constants.py
@@ -8,7 +8,7 @@ DAC_PRECISION = 3  # decimal place precision for voltage conversions
 SW_RESET = 0x1234  # software reset command data bits
 NULL_BITS = 0x0
 READ_WRITE_SIZE = 3  # size of DAC read/write in bytes
-UPPER_LIMIT = 5.0005 # upper limit for voltage writes to DAC
+UPPER_LIMIT = 5.000 # upper limit for voltage writes to DAC
 
 
 class EdgePiDacCom(Enum):

--- a/src/edgepi/dac/dac_constants.py
+++ b/src/edgepi/dac/dac_constants.py
@@ -34,14 +34,14 @@ class EdgePiDacCom(Enum):
 class DACChannel(Enum):
     """EdgePi DAC channel addresses"""
 
-    AOUT0 = 0x0
-    AOUT1 = 0x1
-    AOUT2 = 0x2
-    AOUT3 = 0x3
-    AOUT4 = 0x4
-    AOUT5 = 0x5
-    AOUT6 = 0x6
-    AOUT7 = 0x7
+    AOUT1 = 0x0
+    AOUT2 = 0x1
+    AOUT3 = 0x2
+    AOUT4 = 0x3
+    AOUT5 = 0x4
+    AOUT6 = 0x5
+    AOUT7 = 0x6
+    AOUT8 = 0x7
 
 
 NUM_PINS = len(DACChannel)

--- a/src/edgepi/dac/dac_constants.py
+++ b/src/edgepi/dac/dac_constants.py
@@ -51,7 +51,7 @@ class EdgePiDacCalibrationConstants(Enum):
     """EdgePi DAC calibration constants"""
 
     V_RANGE = 5.0000
-    RANGE = 65535
+    RANGE = 65536
     DAC_GAIN_FACTOR = 2
 
 

--- a/src/edgepi/dac/dac_constants.py
+++ b/src/edgepi/dac/dac_constants.py
@@ -8,7 +8,7 @@ DAC_PRECISION = 3  # decimal place precision for voltage conversions
 SW_RESET = 0x1234  # software reset command data bits
 NULL_BITS = 0x0
 READ_WRITE_SIZE = 3  # size of DAC read/write in bytes
-UPPER_LIMIT = 5.0 # upper limit for voltage writes to DAC
+UPPER_LIMIT = 5.000 # upper limit for voltage writes to DAC
 
 
 class EdgePiDacCom(Enum):

--- a/src/edgepi/dac/edgepi_dac.py
+++ b/src/edgepi/dac/edgepi_dac.py
@@ -26,14 +26,14 @@ class EdgePiDAC(spi):
 
     # analog_out number to pin name
     __analog_out_pin_map = {
-        DACChannel.AOUT0.value: AOPins.AO_EN1,
-        DACChannel.AOUT1.value: AOPins.AO_EN2,
-        DACChannel.AOUT2.value: AOPins.AO_EN3,
-        DACChannel.AOUT3.value: AOPins.AO_EN4,
-        DACChannel.AOUT4.value: AOPins.AO_EN5,
-        DACChannel.AOUT5.value: AOPins.AO_EN6,
-        DACChannel.AOUT6.value: AOPins.AO_EN7,
-        DACChannel.AOUT7.value: AOPins.AO_EN8,
+        DACChannel.AOUT1.value: AOPins.AO_EN1,
+        DACChannel.AOUT2.value: AOPins.AO_EN2,
+        DACChannel.AOUT3.value: AOPins.AO_EN3,
+        DACChannel.AOUT4.value: AOPins.AO_EN4,
+        DACChannel.AOUT5.value: AOPins.AO_EN5,
+        DACChannel.AOUT6.value: AOPins.AO_EN6,
+        DACChannel.AOUT7.value: AOPins.AO_EN7,
+        DACChannel.AOUT8.value: AOPins.AO_EN8,
     }
 
     def __init__(self):
@@ -50,6 +50,7 @@ class EdgePiDAC(spi):
         self.gpio = EdgePiGPIO()
 
         self.__dac_power_state = {
+            DACChannel.AOUT8.value: PowerMode.NORMAL.value,
             DACChannel.AOUT7.value: PowerMode.NORMAL.value,
             DACChannel.AOUT6.value: PowerMode.NORMAL.value,
             DACChannel.AOUT5.value: PowerMode.NORMAL.value,
@@ -57,7 +58,6 @@ class EdgePiDAC(spi):
             DACChannel.AOUT3.value: PowerMode.NORMAL.value,
             DACChannel.AOUT2.value: PowerMode.NORMAL.value,
             DACChannel.AOUT1.value: PowerMode.NORMAL.value,
-            DACChannel.AOUT0.value: PowerMode.NORMAL.value,
         }
 
     def __send_to_gpio_pins(self, analog_out: int, voltage: float):

--- a/src/edgepi/dac/edgepi_dac.py
+++ b/src/edgepi/dac/edgepi_dac.py
@@ -117,7 +117,7 @@ class EdgePiDAC(spi):
             `ValueError`: if voltage has more decimal places than DAC accuracy limit
         """
         dac_gain = CalibConst.DAC_GAIN_FACTOR.value if self.__get_gain_state() else 1
-        self.dac_ops.check_range(analog_out.value, 0, NUM_PINS)
+        self.dac_ops.check_range(analog_out.value, 0, NUM_PINS-1)
         self.dac_ops.check_range(voltage, 0, (UPPER_LIMIT*dac_gain))
         code = self.dac_ops.voltage_to_code(analog_out.value, voltage, dac_gain)
         self.log.debug(f'Code: {code}')
@@ -140,7 +140,7 @@ class EdgePiDAC(spi):
 
             `power_mode` (PowerMode): a valid hex code for setting DAC channel power mode
         """
-        self.dac_ops.check_range(analog_out.value, 0, NUM_PINS)
+        self.dac_ops.check_range(analog_out.value, 0, NUM_PINS-1)
         self.__dac_power_state[analog_out.value] = power_mode.value
         power_code = self.dac_ops.generate_power_code(self.__dac_power_state.values())
         cmd = self.dac_ops.combine_command(COM.COM_POWER_DOWN_OP.value, NULL_BITS, power_code)
@@ -164,7 +164,7 @@ class EdgePiDAC(spi):
             (int): code value stored in the input register, can be used to calculate expected
             voltage
         """
-        self.dac_ops.check_range(analog_out.value, 0, NUM_PINS)
+        self.dac_ops.check_range(analog_out.value, 0, NUM_PINS-1)
         # first transfer triggers read mode, second is needed to fetch data
         cmd = self.dac_ops.combine_command(
                 COM.COM_READBACK.value, DACChannel(analog_out.value).value, NULL_BITS

--- a/src/edgepi/dac/edgepi_dac.py
+++ b/src/edgepi/dac/edgepi_dac.py
@@ -83,12 +83,10 @@ class EdgePiDAC(spi):
         """
         pwm_en = GpioPins.PWM1 if analog_out == DACChannel.AOUT1.value else GpioPins.PWM2
         dout = GpioPins.DOUT1 if analog_out == DACChannel.AOUT1.value else GpioPins.DOUT2
-        if self.gpio.get_pin_direction(pwm_en.value) or not self.gpio.read_pin_state(pwm_en.value):
-            self.gpio.set_pin_direction_out(pwm_en.value)
-            self.gpio.set_pin_state(pwm_en.value)
-        if self.gpio.get_pin_direction(dout.value) or not self.gpio.read_pin_state(dout.value):
-            self.gpio.set_pin_direction_out(dout.value)
-            self.gpio.clear_pin_state(dout.value)
+        self.gpio.set_pin_direction_out(pwm_en.value)
+        self.gpio.set_pin_state(pwm_en.value)
+        self.gpio.set_pin_direction_out(dout.value)
+        self.gpio.clear_pin_state(dout.value)
 
     # TODO: Decimal instead of float for precision testing
     def write_voltage(self, analog_out: DACChannel, voltage: float):

--- a/src/edgepi/dac/edgepi_dac.py
+++ b/src/edgepi/dac/edgepi_dac.py
@@ -205,7 +205,7 @@ class EdgePiDAC(spi):
             code_vals (list): list of code values from ch1-ch8
         """
         code_vals = []
-        for ch in range(NUM_PINS):
+        for ch in DACChannel:
             code, _, _ = self.get_state(ch, True, False, False)
             code_vals.append(int(code/2) if enable else code)
         return code_vals

--- a/src/edgepi/dac/edgepi_dac.py
+++ b/src/edgepi/dac/edgepi_dac.py
@@ -207,7 +207,9 @@ class EdgePiDAC(spi):
         code_vals = []
         for ch in DACChannel:
             code, _, _ = self.get_state(ch, True, False, False)
-            code_vals.append(int(code/2) if enable else code)
+            code_vals.append(int(code/CalibConst.DAC_GAIN_FACTOR.value) if enable else\
+                             code*CalibConst.DAC_GAIN_FACTOR.value if code<CalibConst.RANGE.value/2\
+                             else code)
         return code_vals
 
     def enable_dac_gain(self, enable: bool = None, ch_code_handler: bool = False):

--- a/src/edgepi/dac/edgepi_dac.py
+++ b/src/edgepi/dac/edgepi_dac.py
@@ -88,7 +88,7 @@ class EdgePiDAC(spi):
             self.gpio.set_pin_state(pwm_en.value)
         if self.gpio.get_pin_direction(dout.value) or not self.gpio.read_pin_state(dout.value):
             self.gpio.set_pin_direction_out(dout.value)
-            self.gpio.set_pin_state(dout.value)
+            self.gpio.clear_pin_state(dout.value)
 
     # TODO: Decimal instead of float for precision testing
     def write_voltage(self, analog_out: DACChannel, voltage: float):

--- a/src/edgepi/gpio/gpio_configs.py
+++ b/src/edgepi/gpio/gpio_configs.py
@@ -374,16 +374,16 @@ def _generate_DOUT_expander_pins(): #pylint: disable=C0103
                                           dir_out_code.value,
                                           dir_in_code.value,
                                           GpioExpanderAddress.EXP_TWO.value)})
-    pin_dict.update({DOUTPins.DOUT1.value : I2cPinInfo(GpioBOutputSet.SET_OUTPUT_3.value,
-                                                      GpioBOutputClear.CLEAR_OUTPUT_3.value,
-                                                      GpioBPinDirOut.PIN3_DIR_OUT.value,
-                                                      GpioBPinDirIn.PIN3_DIR_IN.value,
-                                                      GpioExpanderAddress.EXP_TWO.value)})
-
-    pin_dict.update({DOUTPins.DOUT2.value : I2cPinInfo(GpioBOutputSet.SET_OUTPUT_4.value,
+    pin_dict.update({DOUTPins.DOUT1.value : I2cPinInfo(GpioBOutputSet.SET_OUTPUT_4.value,
                                                       GpioBOutputClear.CLEAR_OUTPUT_4.value,
                                                       GpioBPinDirOut.PIN4_DIR_OUT.value,
                                                       GpioBPinDirIn.PIN4_DIR_IN.value,
+                                                      GpioExpanderAddress.EXP_TWO.value)})
+
+    pin_dict.update({DOUTPins.DOUT2.value : I2cPinInfo(GpioBOutputSet.SET_OUTPUT_5.value,
+                                                      GpioBOutputClear.CLEAR_OUTPUT_5.value,
+                                                      GpioBPinDirOut.PIN5_DIR_OUT.value,
+                                                      GpioBPinDirIn.PIN5_DIR_IN.value,
                                                       GpioExpanderAddress.EXP_TWO.value)})
     return pin_dict
 
@@ -395,16 +395,16 @@ def _generate_PWM_expander_pins(): #pylint: disable=C0103
         a dictionary of dataclass with gpio information, {'pin_name' : pin_info_dataclass}
     """
     pin_dict = {}
-    pin_dict.update({PWMPins.PWM1.value : I2cPinInfo(GpioBOutputSet.SET_OUTPUT_5.value,
-                                                      GpioBOutputClear.CLEAR_OUTPUT_5.value,
-                                                      GpioBPinDirOut.PIN5_DIR_OUT.value,
-                                                      GpioBPinDirIn.PIN5_DIR_IN.value,
-                                                      GpioExpanderAddress.EXP_TWO.value)})
-
-    pin_dict.update({PWMPins.PWM2.value : I2cPinInfo(GpioBOutputSet.SET_OUTPUT_6.value,
+    pin_dict.update({PWMPins.PWM1.value : I2cPinInfo(GpioBOutputSet.SET_OUTPUT_6.value,
                                                       GpioBOutputClear.CLEAR_OUTPUT_6.value,
                                                       GpioBPinDirOut.PIN6_DIR_OUT.value,
                                                       GpioBPinDirIn.PIN6_DIR_IN.value,
+                                                      GpioExpanderAddress.EXP_TWO.value)})
+
+    pin_dict.update({PWMPins.PWM2.value : I2cPinInfo(GpioBOutputSet.SET_OUTPUT_7.value,
+                                                      GpioBOutputClear.CLEAR_OUTPUT_7.value,
+                                                      GpioBPinDirOut.PIN7_DIR_OUT.value,
+                                                      GpioBPinDirIn.PIN7_DIR_IN.value,
                                                       GpioExpanderAddress.EXP_TWO.value)})
     return pin_dict
 

--- a/src/edgepi/gpio/gpio_configs.py
+++ b/src/edgepi/gpio/gpio_configs.py
@@ -401,7 +401,7 @@ def _generate_PWM_expander_pins(): #pylint: disable=C0103
                                                       GpioBPinDirIn.PIN5_DIR_IN.value,
                                                       GpioExpanderAddress.EXP_TWO.value)})
 
-    pin_dict.update({PWMPins.PWM1.value : I2cPinInfo(GpioBOutputSet.SET_OUTPUT_6.value,
+    pin_dict.update({PWMPins.PWM2.value : I2cPinInfo(GpioBOutputSet.SET_OUTPUT_6.value,
                                                       GpioBOutputClear.CLEAR_OUTPUT_6.value,
                                                       GpioBPinDirOut.PIN6_DIR_OUT.value,
                                                       GpioBPinDirIn.PIN6_DIR_IN.value,

--- a/src/edgepi/gpio/gpio_constants.py
+++ b/src/edgepi/gpio/gpio_constants.py
@@ -199,3 +199,5 @@ class GpioPins(Enum):
     DIN8 = 'DIN8'
     BUZZER = 'BUZZER'
     AUDIO = 'AUDIO'
+    PWM1 = 'PWM1'
+    PWM2 = 'PWM2'

--- a/src/test_edgepi/integration_tests/test_dac/test_dac.py
+++ b/src/test_edgepi/integration_tests/test_dac/test_dac.py
@@ -38,9 +38,6 @@ def test_dac_init(dac):
 @pytest.mark.parametrize(
     "analog_out, voltage, raises",
     [
-        (CH.AOUT0, LOWER_VOLT_LIMIT, does_not_raise()),
-        (CH.AOUT0, 2.5, does_not_raise()),
-        (CH.AOUT0, UPPER_VOLT_LIMIT, does_not_raise()),
         (CH.AOUT1, LOWER_VOLT_LIMIT, does_not_raise()),
         (CH.AOUT1, 2.5, does_not_raise()),
         (CH.AOUT1, UPPER_VOLT_LIMIT, does_not_raise()),
@@ -62,9 +59,12 @@ def test_dac_init(dac):
         (CH.AOUT7, LOWER_VOLT_LIMIT, does_not_raise()),
         (CH.AOUT7, 2.5, does_not_raise()),
         (CH.AOUT7, UPPER_VOLT_LIMIT, does_not_raise()),
-        (CH.AOUT0, -0.1, pytest.raises(ValueError)),
-        (CH.AOUT0, 5.118, pytest.raises(ValueError)),
-        (CH.AOUT0, 5.1111, pytest.raises(ValueError)),
+        (CH.AOUT8, LOWER_VOLT_LIMIT, does_not_raise()),
+        (CH.AOUT8, 2.5, does_not_raise()),
+        (CH.AOUT8, UPPER_VOLT_LIMIT, does_not_raise()),
+        (CH.AOUT1, -0.1, pytest.raises(ValueError)),
+        (CH.AOUT2, 5.118, pytest.raises(ValueError)),
+        (CH.AOUT3, 5.1111, pytest.raises(ValueError)),
     ],
 )
 def test_dac_write_and_read_voltages(analog_out, voltage, raises, dac):

--- a/src/test_edgepi/unit_tests/test_dac/test_dac_commands.py
+++ b/src/test_edgepi/unit_tests/test_dac/test_dac_commands.py
@@ -59,7 +59,9 @@ def test_dac_check_for_int_exception(sample, error, dac_ops):
 
 @pytest.mark.parametrize(
     "range_min, target, range_max, result",
-    [(0, 0, 10, True), (0, 5, 10, True), (0.5, 1, 1.1, True)],
+    [(0, 0, 10, True),
+     (0, 5, 10, True),
+     (0.5, 1, 1.1, True)],
 )
 def test_dac_check_range(range_min, target, range_max, result, dac_ops):
     assert dac_ops.check_range(target, range_min, range_max) == result
@@ -71,7 +73,7 @@ def test_dac_check_range(range_min, target, range_max, result, dac_ops):
         (0, -1, len(CH), ValueError),
         (0, 11, len(CH), ValueError),
         (0, -5, CALIB_CONSTS.RANGE.value, ValueError),
-        (0, 65536, CALIB_CONSTS.RANGE.value, ValueError),
+        (0, 65536, (CALIB_CONSTS.RANGE.value)-1, ValueError),
     ],
 )
 def test_dac_check_range_raises(range_min, target, range_max, error, dac_ops):

--- a/src/test_edgepi/unit_tests/test_dac/test_dac_commands.py
+++ b/src/test_edgepi/unit_tests/test_dac/test_dac_commands.py
@@ -59,7 +59,7 @@ def test_dac_check_for_int_exception(sample, error, dac_ops):
 
 @pytest.mark.parametrize(
     "range_min, target, range_max, result",
-    [(0, 0, 10, True), (0, 10, 10, True), (0, 5, 10, True), (0.5, 1, 1.1, True)],
+    [(0, 0, 10, True), (0, 5, 10, True), (0.5, 1, 1.1, True)],
 )
 def test_dac_check_range(range_min, target, range_max, result, dac_ops):
     assert dac_ops.check_range(target, range_min, range_max) == result
@@ -109,7 +109,7 @@ def test_dac_generate_write_and_update_command(a, b, c, dac_ops):
 
 
 @pytest.mark.parametrize("ch, expected, dac_gain, result",
-                        [(1, 2.345, 1, 30293), (0, 2.345, 2, 15221), (3, 2.345, 1, 30229)])
+                        [(1, 2.345, 1, 30293), (0, 2.345, 2, 15221), (3, 2.345, 1, 30230)])
 def test_dac_voltage_to_code(ch, expected, dac_gain, result, dac_ops):
     assert dac_ops.voltage_to_code(ch, expected, dac_gain) == result
 

--- a/src/test_edgepi/unit_tests/test_dac/test_edgepi_dac.py
+++ b/src/test_edgepi/unit_tests/test_dac/test_edgepi_dac.py
@@ -324,7 +324,7 @@ def test_get_state(mocker, analog_out, code, voltage, gain, result, mock_val):
     assert pytest.approx(voltage_val, 1e-3) == voltage_val
     assert gain_state == result[2]
 
-@pytest.mark.parametrize("analog_out, result", 
+@pytest.mark.parametrize("analog_out, result",
                         [(CH.AOUT1.value,  [1, 'PWM1']),
                          (CH.AOUT2.value,  [1, 'PWM2']),
                         ])
@@ -344,4 +344,3 @@ def test__dac_switching_logic(mocker, analog_out, result):
 
     assert mock_set_pin_dir_out.call_count == result[0]
     mock_set_pin_state.assert_called_once_with(result[1])
-

--- a/src/test_edgepi/unit_tests/test_dac/test_edgepi_dac.py
+++ b/src/test_edgepi/unit_tests/test_dac/test_edgepi_dac.py
@@ -20,6 +20,7 @@ from edgepi.dac.dac_constants import (
     PowerMode,
     DACChannel as CH,
     EdgePiDacCom as COM,
+    EdgePiDacCalibrationConstants as CalibConst
 )
 from edgepi.dac.edgepi_dac import EdgePiDAC
 from edgepi.calibration.calibration_constants import CalibParam
@@ -243,18 +244,11 @@ def test_write_voltage(mocker,analog_out, voltage, mock_value, result, dac_mock_
     assert result[0] == dac_mock_periph.write_voltage(analog_out, voltage)
 
 @pytest.mark.parametrize("enable, result, mock_vals,",
-                        [(True, [500,500,500,500,500,500,500,500], [[1000, 0, 0],[1000, 0, 0],
-                                                                    [1000, 0, 0],[1000, 0, 0],
-                                                                    [1000, 0, 0],[1000, 0, 0],
-                                                                    [1000, 0, 0],[1000, 0, 0],]),
-                        (True, [500,500,500,500,500,500,500,500], [[1001, 0, 0],[1001, 0, 0],
-                                                                    [1001, 0, 0],[1001, 0, 0],
-                                                                    [1001, 0, 0],[1001, 0, 0],
-                                                                    [1001, 0, 0],[1001, 0, 0],]),
-                         (False, [1000,1000,1000,1000,1000,1000,1000,1000], [[1000,0,0],[1000,0,0],
-                                                                             [1000,0,0],[1000,0,0],
-                                                                             [1000,0,0],[1000,0,0],
-                                                                             [1000,0,0],[1000,0,0]])
+                        [(True, [500]*8, [[1000,0,0]]*8),
+                        (True, [500]*8, [[1001,0,0]]*8),
+                        (False, [2000]*8, [[1000,0,0]]*8),
+                        (False, [CalibConst.RANGE.value/2]*8,[[CalibConst.RANGE.value/2,0,0]]*8),
+                        (False, [CalibConst.RANGE.value-2]*8,[[CalibConst.RANGE.value/2 -1,0,0]]*8)
                         ])
 def test__compute_ch_code_vals(mocker, enable, result, mock_vals):
     mocker.patch("edgepi.peripherals.spi.SPI")

--- a/src/test_edgepi/unit_tests/test_dac/test_edgepi_dac.py
+++ b/src/test_edgepi/unit_tests/test_dac/test_edgepi_dac.py
@@ -61,6 +61,7 @@ def fixture_test_dac_write_voltage(mocker):
 
 
 _default_power_modes = {
+    CH.AOUT8.value: PowerMode.NORMAL.value,
     CH.AOUT7.value: PowerMode.NORMAL.value,
     CH.AOUT6.value: PowerMode.NORMAL.value,
     CH.AOUT5.value: PowerMode.NORMAL.value,
@@ -68,43 +69,42 @@ _default_power_modes = {
     CH.AOUT3.value: PowerMode.NORMAL.value,
     CH.AOUT2.value: PowerMode.NORMAL.value,
     CH.AOUT1.value: PowerMode.NORMAL.value,
-    CH.AOUT0.value: PowerMode.NORMAL.value,
 }
 
 
 @pytest.mark.parametrize(
     "power_modes, analog_out, mode, expected",
     [
-        (deepcopy(_default_power_modes), CH.AOUT7, PowerMode.POWER_DOWN_GROUND, [64, 64, 0]),
-        (deepcopy(_default_power_modes), CH.AOUT7, PowerMode.POWER_DOWN_3_STATE, [64, 192, 0]),
-        (deepcopy(_default_power_modes), CH.AOUT7, PowerMode.NORMAL, [64, 0, 0]),
+        (deepcopy(_default_power_modes), CH.AOUT8, PowerMode.POWER_DOWN_GROUND, [64, 64, 0]),
+        (deepcopy(_default_power_modes), CH.AOUT8, PowerMode.POWER_DOWN_3_STATE, [64, 192, 0]),
+        (deepcopy(_default_power_modes), CH.AOUT8, PowerMode.NORMAL, [64, 0, 0]),
         (
             {
-                CH.AOUT7.value: PowerMode.POWER_DOWN_GROUND.value,
+                CH.AOUT8.value: PowerMode.POWER_DOWN_GROUND.value,
+                CH.AOUT7.value: PowerMode.NORMAL.value,
                 CH.AOUT6.value: PowerMode.NORMAL.value,
                 CH.AOUT5.value: PowerMode.NORMAL.value,
                 CH.AOUT4.value: PowerMode.NORMAL.value,
                 CH.AOUT3.value: PowerMode.NORMAL.value,
                 CH.AOUT2.value: PowerMode.NORMAL.value,
                 CH.AOUT1.value: PowerMode.NORMAL.value,
-                CH.AOUT0.value: PowerMode.NORMAL.value,
             },
-            CH.AOUT7,
+            CH.AOUT8,
             PowerMode.NORMAL,
             [64, 0, 0],
         ),
         (
             {
+                CH.AOUT8.value: PowerMode.NORMAL.value,
                 CH.AOUT7.value: PowerMode.NORMAL.value,
-                CH.AOUT6.value: PowerMode.NORMAL.value,
-                CH.AOUT5.value: PowerMode.POWER_DOWN_GROUND.value,
+                CH.AOUT6.value: PowerMode.POWER_DOWN_GROUND.value,
+                CH.AOUT5.value: PowerMode.NORMAL.value,
                 CH.AOUT4.value: PowerMode.NORMAL.value,
                 CH.AOUT3.value: PowerMode.NORMAL.value,
                 CH.AOUT2.value: PowerMode.NORMAL.value,
                 CH.AOUT1.value: PowerMode.NORMAL.value,
-                CH.AOUT0.value: PowerMode.NORMAL.value,
             },
-            CH.AOUT5,
+            CH.AOUT6,
             PowerMode.NORMAL,
             [0x40, 0, 0],
         ),
@@ -123,14 +123,14 @@ def test_dac_reset(mocker, dac):
     mock_transfer.assert_called_once_with([96, 18, 52])
 
 @pytest.mark.parametrize("analog_out, mock_val",
-                         [(CH.AOUT0, [0xA1,0x69, 0xDF]),
-                          (CH.AOUT1, [0xA1,0x69, 0xDF]),
-                          (CH.AOUT2, [0xA1,0x69, 0xDF]),
-                          (CH.AOUT3, [0xA1,0x69, 0xDF]),
-                          (CH.AOUT4, [0xA1,0x69, 0xDF]),
-                          (CH.AOUT5, [0xA1,0x69, 0xDF]),
+                         [(CH.AOUT8, [0xA1,0x69, 0xDF]),
+                          (CH.AOUT7, [0xA1,0x69, 0xDF]),
                           (CH.AOUT6, [0xA1,0x69, 0xDF]),
-                          (CH.AOUT7, [0xA1,0x69, 0xDF])])
+                          (CH.AOUT5, [0xA1,0x69, 0xDF]),
+                          (CH.AOUT4, [0xA1,0x69, 0xDF]),
+                          (CH.AOUT3, [0xA1,0x69, 0xDF]),
+                          (CH.AOUT2, [0xA1,0x69, 0xDF]),
+                          (CH.AOUT1, [0xA1,0x69, 0xDF])])
 def test_channel_readback(mocker, analog_out, mock_val, dac):
     mocker.patch("edgepi.peripherals.spi.SpiDevice.transfer", return_value=mock_val)
     bits = pack("uint:8, uint:8, uint:8", mock_val[0], mock_val[1], mock_val[2])
@@ -141,6 +141,7 @@ def test_channel_readback(mocker, analog_out, mock_val, dac):
 @pytest.mark.parametrize(
     "analog_out, read_data",
     [
+        (CH.AOUT8, [0, 0, 0]),
         (CH.AOUT7, [0, 0, 0]),
         (CH.AOUT6, [0, 0, 0]),
         (CH.AOUT5, [0, 0, 0]),
@@ -148,7 +149,6 @@ def test_channel_readback(mocker, analog_out, mock_val, dac):
         (CH.AOUT3, [0, 0, 0]),
         (CH.AOUT2, [0, 0, 0]),
         (CH.AOUT1, [0, 0, 0]),
-        (CH.AOUT0, [0, 0, 0]),
     ]
 )
 def test_dac_compute_expected_voltage(mocker, analog_out, read_data, dac):
@@ -225,14 +225,14 @@ def test_send_to_gpio_pins_raises(analog_out, voltage, dac):
 
 
 @pytest.mark.parametrize("analog_out, voltage, mock_value, result",
-                         [(CH.AOUT0, 2.123, [None, None, True], [13913]),
-                          (CH.AOUT1, 2.123, [None, None, True], [13913]),
-                          (CH.AOUT2, 2.123, [None, None, True], [13913]),
-                          (CH.AOUT3, 2.123, [None, None, True], [13913]),
+                         [(CH.AOUT8, 2.123, [None, None, True], [13913]),
+                          (CH.AOUT7, 2.123, [None, None, True], [13913]),
+                          (CH.AOUT6, 2.123, [None, None, True], [13913]),
+                          (CH.AOUT5, 2.123, [None, None, True], [13913]),
                           (CH.AOUT4, 2.123, [None, None, False], [27826]),
-                          (CH.AOUT5, 2.123, [None, None, False], [27826]),
-                          (CH.AOUT6, 2.123, [None, None, False], [27826]),
-                          (CH.AOUT7, 2.123, [None, None, False], [27826])
+                          (CH.AOUT3, 2.123, [None, None, False], [27826]),
+                          (CH.AOUT2, 2.123, [None, None, False], [27826]),
+                          (CH.AOUT1, 2.123, [None, None, False], [27826])
                         ])
 def test_write_voltage(mocker,analog_out, voltage, mock_value, result, dac_mock_periph):
     mocker.patch("edgepi.dac.edgepi_dac.EdgePiDAC.get_state",
@@ -264,14 +264,14 @@ def test_enable_dac_gain(mocker, enable, result, mocker_values):
         else clear_dac_gain.assert_called_once_with("DAC_GAIN")
 
 @pytest.mark.parametrize("mock_val, analog_out, code, voltage, gain, result",
-    [([0xA1,0x69, 0xDF, True], CH.AOUT0, True, True, True, [27103, 2.116, True]),
-    ([0xA1,0x69, 0xDF, False], CH.AOUT1, True, True, True, [27103, 2.116, False]),
-    ([0xA1,0x69, 0xDF, True], CH.AOUT2, True, True, False, [27103, 2.116, None]),
-    ([0xA1,0x69, 0xDF, True], CH.AOUT3, True, True, None, [27103, 2.116, None]),
+    [([0xA1,0x69, 0xDF, True], CH.AOUT8, True, True, True, [27103, 2.116, True]),
+    ([0xA1,0x69, 0xDF, False], CH.AOUT7, True, True, True, [27103, 2.116, False]),
+    ([0xA1,0x69, 0xDF, True], CH.AOUT6, True, True, False, [27103, 2.116, None]),
+    ([0xA1,0x69, 0xDF, True], CH.AOUT5, True, True, None, [27103, 2.116, None]),
     ([0xA1,0x69, 0xDF, True], CH.AOUT4, True, False, True, [27103, None, True]),
-    ([0xA1,0x69, 0xDF, True], CH.AOUT5, True, None, True, [27103, None, True]),
-    ([0xA1,0x69, 0xDF, True], CH.AOUT6, False, True, True, [None, 2.116, True]),
-    ([0xA1,0x69, 0xDF, True], CH.AOUT7, None, True, True, [None, 2.116, True])])
+    ([0xA1,0x69, 0xDF, True], CH.AOUT3, True, None, True, [27103, None, True]),
+    ([0xA1,0x69, 0xDF, True], CH.AOUT2, False, True, True, [None, 2.116, True]),
+    ([0xA1,0x69, 0xDF, True], CH.AOUT1, None, True, True, [None, 2.116, True])])
 def test_get_state(mocker, analog_out, code, voltage, gain, result, mock_val):
     mocker.patch("edgepi.peripherals.spi.SPI")
     mocker.patch("edgepi.peripherals.i2c.I2C")

--- a/src/test_edgepi/unit_tests/test_dac/test_edgepi_dac.py
+++ b/src/test_edgepi/unit_tests/test_dac/test_edgepi_dac.py
@@ -290,7 +290,9 @@ def test_get_state(mocker, analog_out, code, voltage, gain, result, mock_val):
     assert gain_state == result[2]
 
 # TODO: add more test case 
-@pytest.mark.parametrize("analog_out, mock_val, result", [(CH.AOUT1.value, [False, True], 2)])
+@pytest.mark.parametrize("analog_out, mock_val, result", 
+                        [(CH.AOUT1.value, [False, True], [2, 'PWM1', 'DOUT1'])
+                        ])
 def test__dac_switching_logic(mocker, analog_out, mock_val, result):
     mocker.patch("edgepi.peripherals.spi.SPI")
     mocker.patch("edgepi.peripherals.i2c.I2C")
@@ -299,6 +301,7 @@ def test__dac_switching_logic(mocker, analog_out, mock_val, result):
     mocker.patch("edgepi.dac.edgepi_dac.EdgePiGPIO.get_pin_direction", return_value = mock_val[1])
     mock_set_pin_dir_out = mocker.patch("edgepi.dac.edgepi_dac.EdgePiGPIO.set_pin_direction_out")
     mock_set_pin_state = mocker.patch("edgepi.dac.edgepi_dac.EdgePiGPIO.set_pin_state")
+    mock_clear_pin_state = mocker.patch("edgepi.dac.edgepi_dac.EdgePiGPIO.clear_pin_state")
     eelayout= EepromLayout()
     eelayout.ParseFromString(read_binfile())
     mocker.patch("edgepi.dac.edgepi_dac.EdgePiEEPROM.get_edgepi_reserved_data",
@@ -307,7 +310,7 @@ def test__dac_switching_logic(mocker, analog_out, mock_val, result):
     dac.dac_ops.dict_calib_param = dummy_calib_param_dict
     dac._EdgePiDAC__dac_switching_logic(analog_out)
 
-    assert mock_set_pin_dir_out.call_count == result
-    assert mock_set_pin_state.call_count == result
-
+    assert mock_set_pin_dir_out.call_count == result[0]
+    mock_set_pin_state.assert_called_once_with(result[1])
+    mock_clear_pin_state.assert_called_once_with(result[2])
 

--- a/src/test_edgepi/unit_tests/test_dac/test_edgepi_dac.py
+++ b/src/test_edgepi/unit_tests/test_dac/test_edgepi_dac.py
@@ -165,27 +165,27 @@ def test_dac_compute_expected_voltage(mocker, analog_out, read_data, dac):
 
 
 @pytest.mark.parametrize(
-    "analog_out, pin_name, voltage, result",
+    "analog_out, voltage, result",
     [
-        (0, AOPins.AO_EN1.value, 1.0, [2,1,GpioPins.DOUT1.value]),
-        (1, AOPins.AO_EN2.value, 1.0, [2,1,GpioPins.DOUT2.value]),
-        (2, AOPins.AO_EN3.value, 1.0, [1,1,GpioPins.DOUT3.value]),
-        (3, AOPins.AO_EN4.value, 1.0, [1,1,GpioPins.DOUT4.value]),
-        (4, AOPins.AO_EN5.value, 1.0, [1,1,GpioPins.DOUT5.value]),
-        (5, AOPins.AO_EN6.value, 1.0, [1,1,GpioPins.DOUT6.value]),
-        (6, AOPins.AO_EN7.value, 1.0, [1,1,GpioPins.DOUT7.value]),
-        (7, AOPins.AO_EN8.value, 1.0, [1,1,GpioPins.DOUT8.value]),
-        (0, AOPins.AO_EN1.value, 0, [1,1,AOPins.AO_EN1.value]),
-        (1, AOPins.AO_EN2.value, 0, [1,1,AOPins.AO_EN2.value]),
-        (2, AOPins.AO_EN3.value, 0, [0,1,AOPins.AO_EN3.value]),
-        (3, AOPins.AO_EN4.value, 0, [0,1,AOPins.AO_EN4.value]),
-        (4, AOPins.AO_EN5.value, 0, [0,1,AOPins.AO_EN5.value]),
-        (5, AOPins.AO_EN6.value, 0, [0,1,AOPins.AO_EN6.value]),
-        (6, AOPins.AO_EN7.value, 0, [0,1,AOPins.AO_EN7.value]),
-        (7, AOPins.AO_EN8.value, 0, [0,1,AOPins.AO_EN8.value]),
+        (0, 1.0, [2,1,GpioPins.DOUT1.value]),
+        (1, 1.0, [2,1,GpioPins.DOUT2.value]),
+        (2, 1.0, [1,1,GpioPins.DOUT3.value]),
+        (3, 1.0, [1,1,GpioPins.DOUT4.value]),
+        (4, 1.0, [1,1,GpioPins.DOUT5.value]),
+        (5, 1.0, [1,1,GpioPins.DOUT6.value]),
+        (6, 1.0, [1,1,GpioPins.DOUT7.value]),
+        (7, 1.0, [1,1,GpioPins.DOUT8.value]),
+        (0, 0, [1,1,AOPins.AO_EN1.value]),
+        (1, 0, [1,1,AOPins.AO_EN2.value]),
+        (2, 0, [0,1,AOPins.AO_EN3.value]),
+        (3, 0, [0,1,AOPins.AO_EN4.value]),
+        (4, 0, [0,1,AOPins.AO_EN5.value]),
+        (5, 0, [0,1,AOPins.AO_EN6.value]),
+        (6, 0, [0,1,AOPins.AO_EN7.value]),
+        (7, 0, [0,1,AOPins.AO_EN8.value]),
     ]
 )
-def test_dac_send_to_gpio_pins(mocker, analog_out, pin_name, voltage, result):
+def test_dac_send_to_gpio_pins(mocker, analog_out, voltage, result):
     # can't mock entire GPIO class here because need to access its methods
     mocker.patch("edgepi.peripherals.spi.SPI")
     mocker.patch("edgepi.peripherals.i2c.I2C")
@@ -231,10 +231,11 @@ def test_send_to_gpio_pins_raises(analog_out, voltage, dac):
                           (CH.AOUT7, 2.123, [None, None, True], [13913]),
                           (CH.AOUT6, 2.123, [None, None, True], [13913]),
                           (CH.AOUT5, 2.123, [None, None, True], [13913]),
-                          (CH.AOUT4, 2.123, [None, None, False], [27826]),
-                          (CH.AOUT3, 2.123, [None, None, False], [27826]),
-                          (CH.AOUT2, 2.123, [None, None, False], [27826]),
-                          (CH.AOUT1, 2.123, [None, None, False], [27826])
+                          (CH.AOUT5, 9.999, [None, None, True], [65529]),
+                          (CH.AOUT4, 2.123, [None, None, False], [27827]),
+                          (CH.AOUT3, 2.123, [None, None, False], [27827]),
+                          (CH.AOUT2, 2.123, [None, None, False], [27827]),
+                          (CH.AOUT1, 2.123, [None, None, False], [27827])
                         ])
 def test_write_voltage(mocker,analog_out, voltage, mock_value, result, dac_mock_periph):
     mocker.patch("edgepi.dac.edgepi_dac.EdgePiDAC.get_state",

--- a/tests/hardware_tests/test_voltage_rw.py
+++ b/tests/hardware_tests/test_voltage_rw.py
@@ -22,14 +22,14 @@ WRITE_READ_DELAY = 0.1
 
 
 _ch_map = {
-    0: (ADCChannel.AIN0, DACChannel.AOUT0),
-    1: (ADCChannel.AIN1, DACChannel.AOUT1),
-    2: (ADCChannel.AIN2, DACChannel.AOUT2),
-    3: (ADCChannel.AIN3, DACChannel.AOUT3),
-    4: (ADCChannel.AIN4, DACChannel.AOUT4),
-    5: (ADCChannel.AIN5, DACChannel.AOUT5),
-    6: (ADCChannel.AIN6, DACChannel.AOUT6),
-    7: (ADCChannel.AIN7, DACChannel.AOUT7),
+    0: (ADCChannel.AIN0, DACChannel.AOUT1),
+    1: (ADCChannel.AIN1, DACChannel.AOUT2),
+    2: (ADCChannel.AIN2, DACChannel.AOUT3),
+    3: (ADCChannel.AIN3, DACChannel.AOUT4),
+    4: (ADCChannel.AIN4, DACChannel.AOUT5),
+    5: (ADCChannel.AIN5, DACChannel.AOUT6),
+    6: (ADCChannel.AIN6, DACChannel.AOUT7),
+    7: (ADCChannel.AIN7, DACChannel.AOUT8),
 }
 
 
@@ -135,14 +135,14 @@ def _measure_voltage_differential(
 
 
 _diff_ch_map = {
-    ADCChannel.AIN0: DACChannel.AOUT0,
-    ADCChannel.AIN1: DACChannel.AOUT1,
-    ADCChannel.AIN2: DACChannel.AOUT2,
-    ADCChannel.AIN3: DACChannel.AOUT3,
-    ADCChannel.AIN4: DACChannel.AOUT4,
-    ADCChannel.AIN5: DACChannel.AOUT5,
-    ADCChannel.AIN6: DACChannel.AOUT6,
-    ADCChannel.AIN7: DACChannel.AOUT7,
+    ADCChannel.AIN0: DACChannel.AOUT1,
+    ADCChannel.AIN1: DACChannel.AOUT2,
+    ADCChannel.AIN2: DACChannel.AOUT3,
+    ADCChannel.AIN3: DACChannel.AOUT4,
+    ADCChannel.AIN4: DACChannel.AOUT5,
+    ADCChannel.AIN5: DACChannel.AOUT6,
+    ADCChannel.AIN6: DACChannel.AOUT7,
+    ADCChannel.AIN7: DACChannel.AOUT8,
 }
 
 


### PR DESCRIPTION
Closes #293, #290

- Modified DAC module to accommodate the hardware changes
- enable_dac_gain() issue resolved by passing channel code handler flag
   - re-write channels with appropriate code
   - when enable_dac_gain(False), it caps at the maximum allowable code, [this](https://github.com/EdgePi-Cloud/edgepi-python-sdk/blob/9f669e54743ff67d86cef9dad5c249924b6a8705/src/edgepi/dac/edgepi_dac.py#L207-L212) lines

