### PR TITLE
adding valueError to raise when the code value is out of range

### DIFF
--- a/src/edgepi/dac/README.md
+++ b/src/edgepi/dac/README.md
@@ -14,7 +14,7 @@ from edgepi.dac.edgepi_dac import EdgePiDAC
 edgepi_dac = EdgePiDAC()
 
 # setting DAC range 0-5V
-edgepi_dac.enable_dac_gain(False)
+edgepi_dac.toggle_dac_gain(False)
 
 # write voltage value of 3.3 V to analog out pin number 1
 edgepi_dac.write_voltage(Ch.AOUT1, 3.3)
@@ -32,12 +32,12 @@ This section introduces DAC functionality available to users, and provides a gui
 1. setting output voltage range
 
 ```python
-    def enable_dac_gain(self, enable: bool = None, ch_code_handler: bool = False):
+    def toggle_dac_gain(self, toggle_gain: bool = None, auto_code_change: bool = False):
         """
         Enable/Disable internal DAC gain by toggling the DAC_GAIN pin
         Args:
-            enable (bool): enable boolean to set or clear the gpio pin
-            ch_code_handler (bool): flag to re-write code value of each channel to keep the same
+            toggle_gain (bool): enable boolean to set or clear the gpio pin
+            auto_code_change (bool): flag to re-write code value of each channel to keep the same
                                     output voltage
         Return:
             gain_state (bool): state of the gain pin

--- a/src/edgepi/dac/README.md
+++ b/src/edgepi/dac/README.md
@@ -32,11 +32,11 @@ This section introduces DAC functionality available to users, and provides a gui
 1. setting output voltage range
 
 ```python
-    def toggle_dac_gain(self, toggle_gain: bool = None, auto_code_change: bool = False):
+    def set_dac_gain(self, set_gain: bool, auto_code_change: bool = False):
         """
         Enable/Disable internal DAC gain by toggling the DAC_GAIN pin
         Args:
-            toggle_gain (bool): enable boolean to set or clear the gpio pin
+            set_gain (bool): enable boolean to set or clear the gpio pin
             auto_code_change (bool): flag to re-write code value of each channel to keep the same
                                     output voltage
         Return:

--- a/src/edgepi/dac/edgepi_dac.py
+++ b/src/edgepi/dac/edgepi_dac.py
@@ -261,9 +261,9 @@ class EdgePiDAC(spi):
 
     def set_dac_gain(self, set_gain: bool, auto_code_change: bool = False):
         """
-        Enable/Disable internal DAC gain by toggling the DAC_GAIN pin
+        Enable/Disable internal DAC gain.
         Args:
-            set_gain (bool): enable boolean to set or clear the gpio pin
+            set_gain (bool): True enable DAC gain, False disable DAC gain
             auto_code_change (bool): flag to re-write code value of each channel to keep the same
                                     output voltage
         Return:

--- a/src/edgepi/dac/edgepi_dac.py
+++ b/src/edgepi/dac/edgepi_dac.py
@@ -208,8 +208,10 @@ class EdgePiDAC(spi):
         """
         if enable:
             return int(code/CalibConst.DAC_GAIN_FACTOR.value)
-        if code<CalibConst.RANGE.value/2:
-            return code*CalibConst.DAC_GAIN_FACTOR.value
+
+        code = code*CalibConst.DAC_GAIN_FACTOR.value
+        if code > CalibConst.RANGE.value:
+            raise ValueError(f"Code Value: {code} is out of range")
 
         return code
 

--- a/src/edgepi/dac/edgepi_dac.py
+++ b/src/edgepi/dac/edgepi_dac.py
@@ -199,7 +199,7 @@ class EdgePiDAC(spi):
         """
         Modify code value depending on the enable flag
         Args:
-            toggle_gain(bool): False: multiply the current code value by 2 if current code value is 
+            toggle_gain(bool): False: multiply the current code value by 2 if current code value is
                                less than the half of maixmum code value.
                                True: divide the current code value by 2
             code (int): intial code value
@@ -240,7 +240,7 @@ class EdgePiDAC(spi):
         """
         codes = self.__get_ch_codes(toggle_gain)
         self.log.debug(f'Code: {codes}')
-            
+
         # gain being enabled, change code first than enable gain
         if toggle_gain:
             for ch, code in enumerate(codes):
@@ -265,6 +265,7 @@ class EdgePiDAC(spi):
         Return:
             gain_state (bool): state of the gain pin
         """
+        # pylint: disable=expression-not-assigned
         # if current gain state is the same as toggle_gain flag, do nothing
         if self.__get_gain_state() == toggle_gain:
             return toggle_gain
@@ -272,7 +273,6 @@ class EdgePiDAC(spi):
         if auto_code_change:
             self.__auto_code_handler(toggle_gain)
         else:
-            # pylint: disable=expression-not-assigned
             self.gpio.set_pin_state(GainPin.DAC_GAIN.value) if toggle_gain else \
             self.gpio.clear_pin_state(GainPin.DAC_GAIN.value)
         return self.__get_gain_state()

--- a/src/test_edgepi/integration_tests/test_dac/test_dac.py
+++ b/src/test_edgepi/integration_tests/test_dac/test_dac.py
@@ -85,11 +85,11 @@ def test_dac_write_and_read_voltages(analog_out, voltage, raises, dac):
     ],
 )
 def test_dac_gain(gain_enable,dac):
-    dac.toggle_dac_gain(not gain_enable)
+    dac.set_dac_gain(not gain_enable)
     _, _, initial_gain_state = dac.get_state(None, False, False, True)
-    gain_state = dac.toggle_dac_gain(gain_enable)
+    gain_state = dac.set_dac_gain(gain_enable)
     assert initial_gain_state != gain_state
-    dac.toggle_dac_gain(False)
+    dac.set_dac_gain(False)
 
 def test_dac_reset(dac):
     voltage = 2.2

--- a/src/test_edgepi/integration_tests/test_dac/test_dac.py
+++ b/src/test_edgepi/integration_tests/test_dac/test_dac.py
@@ -85,11 +85,11 @@ def test_dac_write_and_read_voltages(analog_out, voltage, raises, dac):
     ],
 )
 def test_dac_gain(gain_enable,dac):
-    dac.enable_dac_gain(not gain_enable)
+    dac.toggle_dac_gain(not gain_enable)
     _, _, initial_gain_state = dac.get_state(None, False, False, True)
-    gain_state = dac.enable_dac_gain(gain_enable)
+    gain_state = dac.toggle_dac_gain(gain_enable)
     assert initial_gain_state != gain_state
-    dac.enable_dac_gain(False)
+    dac.toggle_dac_gain(False)
 
 def test_dac_reset(dac):
     voltage = 2.2

--- a/src/test_edgepi/unit_tests/test_dac/test_edgepi_dac.py
+++ b/src/test_edgepi/unit_tests/test_dac/test_edgepi_dac.py
@@ -12,6 +12,7 @@ sys.modules['periphery'] = mock.MagicMock()
 # https://github.com/protocolbuffers/protobuf/issues/10372
 # pylint: disable=protected-access
 
+from contextlib import nullcontext as does_not_raise
 import pytest
 from bitstring import pack
 from edgepi.gpio.gpio_constants import GpioPins
@@ -244,13 +245,13 @@ def test_write_voltage(mocker,analog_out, voltage, mock_value, result, dac_mock_
     mocker.patch("edgepi.dac.edgepi_dac.EdgePiGPIO.set_expander_pin")
     assert result[0] == dac_mock_periph.write_voltage(analog_out, voltage)
 
-@pytest.mark.parametrize("enable, code, result",
-                         [(True, 2000, 1000),
-                          (True, CalibConst.RANGE.value-1, 32767),
-                          (False, CalibConst.RANGE.value-1, CalibConst.RANGE.value-1),
-                          (False, CalibConst.RANGE.value/2 -1, CalibConst.RANGE.value-2),
-                                                 ])
-def test__modify_code_val(mocker, enable, code, result):
+@pytest.mark.parametrize("enable, code, result, error",
+                    [(True, 2000, 1000, does_not_raise()),
+                    (True, CalibConst.RANGE.value-1, 32767, does_not_raise()),
+                    (False, CalibConst.RANGE.value-1, 0, pytest.raises(ValueError)),
+                    (False,CalibConst.RANGE.value/2-1,CalibConst.RANGE.value-2,does_not_raise()),
+                    ])
+def test__modify_code_val(mocker, enable, code, result, error):
     mocker.patch("edgepi.peripherals.spi.SPI")
     mocker.patch("edgepi.peripherals.i2c.I2C")
     mocker.patch("edgepi.gpio.edgepi_gpio_expander.I2CDevice")
@@ -260,17 +261,26 @@ def test__modify_code_val(mocker, enable, code, result):
                   return_value = EdgePiEEPROMData(eelayout))
     dac = EdgePiDAC()
     dac.dac_ops.dict_calib_param = dummy_calib_param_dict
-    assert dac._EdgePiDAC__modify_code_val(enable, code) == result
+    with error:
+        assert dac._EdgePiDAC__modify_code_val(enable, code) == result
 
 
-@pytest.mark.parametrize("enable, result, mock_vals,",
-                        [(True, [500]*8, [[1000,0,0]]*8),
-                        (True, [500]*8, [[1001,0,0]]*8),
-                        (False, [2000]*8, [[1000,0,0]]*8),
-                        (False, [CalibConst.RANGE.value/2]*8,[[CalibConst.RANGE.value/2,0,0]]*8),
-                        (False, [CalibConst.RANGE.value-2]*8,[[CalibConst.RANGE.value/2 -1,0,0]]*8)
+@pytest.mark.parametrize("enable, result, mock_vals, error,",
+                        [(True, [500]*8, [[1000,0,0]]*8, does_not_raise()),
+                        (True, [500]*8, [[1001,0,0]]*8, does_not_raise()),
+                        (False, [2000]*8, [[1000,0,0]]*8, does_not_raise()),
+                        (False,
+                         [CalibConst.RANGE.value-2]*8,
+                         [[CalibConst.RANGE.value/2 -1,0,0]]*8,
+                         does_not_raise()),
+                        (False,
+                         [CalibConst.RANGE.value]*8,
+                         [[CalibConst.RANGE.value/2,0,0]]*8,
+                         does_not_raise()),
+                        (False, [40000]*8,[[40000,0,0]]*8,pytest.raises(ValueError)),
+                        (False, [40000]*8,[[50000,0,0]]*8,pytest.raises(ValueError)),
                         ])
-def test__get_ch_codes(mocker, enable, result, mock_vals):
+def test__get_ch_codes(mocker, enable, result, mock_vals, error):
     mocker.patch("edgepi.peripherals.spi.SPI")
     mocker.patch("edgepi.peripherals.i2c.I2C")
     mocker.patch("edgepi.gpio.edgepi_gpio_expander.I2CDevice")
@@ -282,19 +292,25 @@ def test__get_ch_codes(mocker, enable, result, mock_vals):
                   return_value = EdgePiEEPROMData(eelayout))
     dac = EdgePiDAC()
     dac.dac_ops.dict_calib_param = dummy_calib_param_dict
-    assert result == dac._EdgePiDAC__get_ch_codes(enable)
+    with error:
+        assert result == dac._EdgePiDAC__get_ch_codes(enable)
 
 @pytest.mark.parametrize("enable, ch_handler, mocker_values, result",
-                        [(True, True, [[False, True],[100]*8], [8, True]),
-                         (True, False, [[True, False],[100]*8], [0, True]),
+                        [
+                        #  Case 1. enable gain and enable channel code handler
+                         (True, True, [[False, True],[100]*8], [8, True]),
+                        #  Case 2. enable gain but no channel code handler
+                         (True, False, [[True, "Don't care"],[100]*8], [0, True]),
+                        #  Case 3. enable gain and code handler, but gain state is already enabled
                          (True, True, [[True, True],[100]*8], [0, True]),
-                         (True, False, [[True, True],[100]*8], [0, True]),
+                        # Case 4. enable gain, no code handler, but gain state is already enabled
+                         (True, False, [[True, "Don't care"],[100]*8], [0, True]),
                          (False, True, [[False, False],[100]*8], [0, False]),
-                         (False, False, [[False, False],[100]*8], [0, False]),
+                         (False, False, [[False, "Dont't care"],[100]*8], [0, False]),
                          (False, True, [[True, False],[100]*8], [8, False]),
-                         (False, False, [[False, False],[100]*8], [0, False]),
+                         (False, False, [[False, "Don't care"],[100]*8], [0, False]),
                          ])
-def test_enable_dac_gain(mocker, enable, ch_handler, result, mocker_values):
+def test_enable_dac_gain(mocker, enable, ch_handler, mocker_values, result):
     mocker.patch("edgepi.peripherals.spi.SPI")
     mocker.patch("edgepi.peripherals.i2c.I2C")
     mocker.patch("edgepi.gpio.edgepi_gpio_expander.I2CDevice")

--- a/src/test_edgepi/unit_tests/test_dac/test_edgepi_dac.py
+++ b/src/test_edgepi/unit_tests/test_dac/test_edgepi_dac.py
@@ -312,6 +312,7 @@ def test__auto_code_handler(mocker, toggle_gain, result):
     dac.dac_ops.dict_calib_param = dummy_calib_param_dict
     dac._EdgePiDAC__auto_code_handler(toggle_gain)
     assert transfer_mock.call_count == result
+    # pylint: disable=expression-not-assigned
     set_dac_gain.assert_called_once_with("DAC_GAIN") if toggle_gain \
         else clear_dac_gain.assert_called_once_with("DAC_GAIN")
 


### PR DESCRIPTION
Closes #290 

- raises valueError when the resulting code of `enable_dac_gain()` code handler exceeds the maximum allowable code value
- revised unittests 