### PR TITLE
Dev pwm refactor

### DIFF
--- a/src/edgepi/pwm/README.md
+++ b/src/edgepi/pwm/README.md
@@ -10,14 +10,12 @@ from edgepi.pwm.pwm_constants import Polarity, PWMPins
 from edgepi.pwm.edgepi_pwm import EdgePiPWM
 
 # Enable PWM1
-edgepi_pwm = EdgePiPWM(PWMPins.PWM1)
+edgepi_pwm = EdgePiPWM()
 
-# Set frequency to 1KHz
-edgepi_pwm.set_frequency(1000)
-# Set Duty Cycle to 50 %
-edgepi_pwm.set_duty_cycle(0.5)
-# Set polarity of PWM to Normal
-edgepi_pwm.set_polarity(Polarity.NORMAL)
+# Initialize and open pwm device
+edgepi_pwm.init_pwm(PWMPins.PWM1)
+# Setting PWM parameters
+edgepi_pwm.set_config(PWMPins.PWM1, 1000, 50)
 # enable the pwm signal 
 edgepi_pwm.enable()
 # disable the pwm signal 

--- a/src/edgepi/pwm/edgepi_pwm.py
+++ b/src/edgepi/pwm/edgepi_pwm.py
@@ -24,8 +24,8 @@ class EdgePiPWM():
     """PWM module to provide PWM signal"""
     __pwm_pin_to_channel = {PWMPins.PWM1 : PWMCh.PWM_1,
                             PWMPins.PWM2 : PWMCh.PWM_2}
-    __pwm_1 = None
-    __pwm_2 = None
+    __pwm_devs = {PWMPins.PWM1 : None,
+                  PWMPins.PWM2 : None}
 
     """handling PWM output"""
     def __init__(self):
@@ -48,13 +48,10 @@ class EdgePiPWM():
         Returns:
             N/A
         """
-        if pwm_num is None:
+        if pwm_num is None or pwm_num not in self.__pwm_devs:
             raise ValueError(f"__set_frequency: PWM number is missing {pwm_num}")
         self.__check_range(frequency, PWM_MIN_FREQ, PWM_MAX_FREQ)
-        if pwm_num == PWMPins.PWM1:
-            self.__pwm_1.set_frequency_pwm(frequency)
-        else:
-            self.__pwm_2.set_frequency_pwm(frequency)
+        self.__pwm_devs[pwm_num].set_frequency_pwm(frequency)
 
     def get_frequency(self, pwm_num: PWMPins):
         """
@@ -64,10 +61,9 @@ class EdgePiPWM():
         Returns:
             frequency (int): frequency value
         """
-        if pwm_num is None:
+        if pwm_num is None or pwm_num not in self.__pwm_devs:
             raise ValueError(f"get_frequency: PWM number is missing {pwm_num}")
-        return self.__pwm_1.get_frequency_pwm() if pwm_num == PWMPins.PWM1 else\
-               self.__pwm_2.get_frequency_pwm()
+        return self.__pwm_devs[pwm_num].get_frequency_pwm()
 
     def __set_duty_cycle(self, pwm_num: PWMPins, duty_cycle: int):
         """
@@ -79,13 +75,10 @@ class EdgePiPWM():
         Returns:
             N/A
         """
-        if pwm_num is None:
+        if pwm_num is None or pwm_num not in self.__pwm_devs:
             raise ValueError(f"__set_duty_cycle: PWM number is missing {pwm_num}")
         self.__check_range(duty_cycle, PWM_MIN_DUTY_CYCLE, PWM_MAX_DUTY_CYCLE)
-        if pwm_num == PWMPins.PWM1:
-            self.__pwm_1.set_duty_cycle_pwm(duty_cycle/100)
-        else:
-            self.__pwm_2.set_duty_cycle_pwm(duty_cycle/100)
+        self.__pwm_devs[pwm_num].set_duty_cycle_pwm(duty_cycle/100)
 
     def get_duty_cycle(self, pwm_num: PWMPins):
         """
@@ -95,10 +88,9 @@ class EdgePiPWM():
         Returns:
             duty_cycle (int): duty_cycle value in percentage
         """
-        if pwm_num is None:
+        if pwm_num is None or pwm_num not in self.__pwm_devs:
             raise ValueError(f"get_duty_cycle: PWM number is missing {pwm_num}")
-        return self.__pwm_1.get_duty_cycle_pwm()*100 if pwm_num == PWMPins.PWM1 else\
-               self.__pwm_2.get_duty_cycle_pwm()*100
+        return self.__pwm_devs[pwm_num].get_duty_cycle_pwm()*100
 
     def __set_polarity(self, pwm_num: PWMPins, polarity: Polarity):
         """
@@ -109,13 +101,9 @@ class EdgePiPWM():
         Returns:
             N/A
         """
-        if pwm_num is None:
+        if pwm_num is None or pwm_num not in self.__pwm_devs:
             raise ValueError(f"__set_polarity: PWM number is missing {pwm_num}")
-        if pwm_num == PWMPins.PWM1:
-            self.__pwm_1.set_polarity_pwm(polarity.value)
-        else:
-            self.__pwm_2.set_polarity_pwm(polarity.value)
-
+        self.__pwm_devs[pwm_num].set_polarity_pwm(polarity.value)
 
     def get_polarity(self, pwm_num: PWMPins):
         """
@@ -125,10 +113,9 @@ class EdgePiPWM():
         Returns:
             polarity (int): polarity value
         """
-        if pwm_num is None:
+        if pwm_num is None or pwm_num not in self.__pwm_devs:
             raise ValueError(f"get_polarity: PWM number is missing {pwm_num}")
-        return self.__pwm_1.get_polarity_pwm() if pwm_num == PWMPins.PWM1 else\
-               self.__pwm_2.get_polarity_pwm()
+        return self.__pwm_devs[pwm_num].get_polarity_pwm()
 
 
     def enable(self, pwm_num: PWMPins):
@@ -139,7 +126,7 @@ class EdgePiPWM():
         Returns:
             N/A
         """
-        if pwm_num is None:
+        if pwm_num is None or pwm_num not in self.__pwm_devs:
             raise ValueError(f"enable: PWM number is missing {pwm_num}")
         if self.get_enabled(pwm_num):
             self.disable(pwm_num)
@@ -149,10 +136,7 @@ class EdgePiPWM():
                                 GpioPins.DOUT2.value)
         self.gpio.clear_pin_state(pwm_num.value)
         self.log.info("enable: Enabling PWM")
-        if pwm_num == PWMPins.PWM1:
-            self.__pwm_1.enable_pwm()
-        else:
-            self.__pwm_2.enable_pwm()
+        self.__pwm_devs[pwm_num].enable_pwm()
 
     def disable(self, pwm_num: PWMPins):
         """
@@ -162,12 +146,9 @@ class EdgePiPWM():
         Returns:
             N/A
         """
-        if pwm_num is None:
+        if pwm_num is None or pwm_num not in self.__pwm_devs:
             raise ValueError(f"disable: PWM number is missing {pwm_num}")
-        if pwm_num == PWMPins.PWM1:
-            self.__pwm_1.disable_pwm()
-        else:
-            self.__pwm_2.disable_pwm()
+        self.__pwm_devs[pwm_num].disable_pwm()
         self.gpio.set_pin_state(pwm_num.value)
 
     def get_enabled(self, pwm_num: PWMPins):
@@ -178,10 +159,9 @@ class EdgePiPWM():
         Returns:
             enabled (bool): True enabled, False Disabled
         """
-        if pwm_num is None:
+        if pwm_num is None or pwm_num not in self.__pwm_devs:
             raise ValueError(f"get_enabled: PWM number is missing {pwm_num}")
-        return self.__pwm_1.get_enabled_pwm() if pwm_num == PWMPins.PWM1 else\
-               self.__pwm_2.get_enabled_pwm()
+        return self.__pwm_devs[pwm_num].get_enabled_pwm()
 
     def close(self, pwm_num: PWMPins):
         """
@@ -191,20 +171,18 @@ class EdgePiPWM():
         Returns:
             N/A
         """
-        if pwm_num is None:
-            raise ValueError(f"close: PWM number is missing {pwm_num}")
-        return self.__pwm_1.close_pwm() if pwm_num == PWMPins.PWM1 else\
-               self.__pwm_2.close_pwm()
+        if pwm_num is None or pwm_num not in self.__pwm_devs:
+            raise ValueError(f"get_enabled: PWM number is missing {pwm_num}")
+        return self.__pwm_devs[pwm_num].close_pwm()
 
-    def __check_pwm_device_and_instantiate(self, pwm_num: PWMPins):
-        # Check if it is first time being called, __pwm
-        if pwm_num == PWMPins.PWM1 and self.__pwm_1 is None:
-            return PwmDevice(channel=self.__pwm_pin_to_channel[PWMPins.PWM1].value.channel,
-                                chip=self.__pwm_pin_to_channel[PWMPins.PWM1].value.chip)
-        if pwm_num == PWMPins.PWM2 and self.__pwm_2 is None:
-            return PwmDevice(channel=self.__pwm_pin_to_channel[PWMPins.PWM2].value.channel,
-                                chip=self.__pwm_pin_to_channel[PWMPins.PWM2].value.chip)
-        return None
+    def __init_pwm_dev(self, pwm_num: PWMPins):
+        self.__pwm_devs[pwm_num]=PwmDevice(channel=self.__pwm_pin_to_channel[pwm_num].value.channel,
+                                           chip=self.__pwm_pin_to_channel[pwm_num].value.chip)
+        self.__pwm_devs[pwm_num].open_pwm()
+        self.log.debug(f"init_pwm: Instantiating PWM Device for the first time "
+                       f"{self.__pwm_devs[pwm_num].chip}"
+                       f",{self.__pwm_devs[pwm_num].channel}")
+
 
     def init_pwm(self, pwm_num: PWMPins):
         """
@@ -214,17 +192,12 @@ class EdgePiPWM():
         Return:
             N/A
         """
-        if pwm_num is None:
+        if pwm_num is None or pwm_num not in self.__pwm_devs:
             raise ValueError(f"init_pwm: PWM number is missing {pwm_num}")
-        pwm_dev = self.__check_pwm_device_and_instantiate(pwm_num)
-        if pwm_dev is not None:
-            pwm_dev.open_pwm()
-            self.log.debug(f"init_pwm: Instantiating PWM Device for the first time {pwm_dev.chip}"
-                           f",{pwm_dev.channel}")
-            if pwm_num == PWMPins.PWM1:
-                self.__pwm_1 = pwm_dev
-            else:
-                self.__pwm_2 = pwm_dev
+        if self.__pwm_devs[pwm_num] is None:
+            self.__init_pwm_dev(pwm_num)
+            return
+
         self.log.debug("init_pwm: PWM device is already open")
 
     def set_config(self, pwm_num: PWMPins,
@@ -244,7 +217,7 @@ class EdgePiPWM():
         """
         if pwm_num is None:
             raise ValueError(f"set_config: PWM number is missing {pwm_num}")
-        if self.__check_pwm_device_and_instantiate(pwm_num) is not None:
+        if self.__pwm_devs[pwm_num] is None:
             raise PwmDeviceError(f"set_config: PWM device doesn't exist {pwm_num},"
                                  f"initialize the device first")
         if self.get_frequency(pwm_num) != frequency:

--- a/src/edgepi/pwm/edgepi_pwm.py
+++ b/src/edgepi/pwm/edgepi_pwm.py
@@ -24,13 +24,13 @@ class EdgePiPWM():
     """PWM module to provide PWM signal"""
     __pwm_pin_to_channel = {PWMPins.PWM1 : PWMCh.PWM_1,
                             PWMPins.PWM2 : PWMCh.PWM_2}
-    __pwm_devs = {PWMPins.PWM1 : None,
-                  PWMPins.PWM2 : None}
 
     """handling PWM output"""
     def __init__(self):
         self.log = logging.getLogger(__name__)
         self.gpio = EdgePiGPIO()
+        self.__pwm_devs = {PWMPins.PWM1 : None,
+                  PWMPins.PWM2 : None}
 
     def __check_range(self, target, range_min, range_max) -> bool:
         """Validates target is in range between a min and max value"""

--- a/src/edgepi/pwm/edgepi_pwm.py
+++ b/src/edgepi/pwm/edgepi_pwm.py
@@ -125,26 +125,42 @@ class EdgePiPWM():
                self.__pwm_2.get_polarity_pwm()
 
 
-    def enable(self):
+    def enable(self, pwm_num: PWMPins):
         """
         Enable pwm output
+        Args:
+            pwm_num (PWMPins): target pwm device
+        Returns:
+            N/A
         """
-        self.gpio.set_pin_state(GpioPins.AO_EN1.value if self.pwm_num==PWMPins.PWM1 else\
+        if pwm_num is None:
+            raise ValueError(f"set_config: PWM number is missing {pwm_num}")
+        if self.get_enabled(pwm_num):
+            self.disable(pwm_num)
+        self.gpio.set_pin_state(GpioPins.AO_EN1.value if pwm_num==PWMPins.PWM1 else\
                                 GpioPins.AO_EN2.value)
-        self.gpio.clear_pin_state(GpioPins.DOUT1.value if self.pwm_num==PWMPins.PWM1 else\
+        self.gpio.clear_pin_state(GpioPins.DOUT1.value if pwm_num==PWMPins.PWM1 else\
                                 GpioPins.DOUT2.value)
-        self.gpio.clear_pin_state(self.pwm_num.value)
-        self.log.info("Enabling PWM")
-        self.pwm.enable_pwm()
+        self.gpio.clear_pin_state(pwm_num.value)
+        self.log.info("enable: Enabling PWM")
+        self.__pwm_1.enable_pwm() if pwm_num == PWMPins.PWM1 else\
+        self.__pwm_2.enable_pwm()
 
-    def disable(self):
+    def disable(self, pwm_num: PWMPins):
         """
         Disable pwm output
+        Args:
+            pwm_num (PWMPins): target pwm device
+        Returns:
+            N/A
         """
-        self.pwm.disable_pwm()
-        self.gpio.set_pin_state(self.pwm_num.value)
+        if pwm_num is None:
+            raise ValueError(f"set_config: PWM number is missing {pwm_num}")
+        self.__pwm_1.disable_pwm() if pwm_num == PWMPins.PWM1 else\
+        self.__pwm_2.disable_pwm()
+        self.gpio.set_pin_state(pwm_num.value)
 
-    def get_enabled(self):
+    def get_enabled(self, pwm_num: PWMPins):
         """
         Get enabled state
         Args:
@@ -152,17 +168,23 @@ class EdgePiPWM():
         Returns:
             enabled (bool): True enabled, False Disabled
         """
-        return self.pwm.get_enabled_pwm()
+        if pwm_num is None:
+            raise ValueError(f"set_config: PWM number is missing {pwm_num}")
+        return self.__pwm_1.get_enabled_pwm() if pwm_num == PWMPins.PWM1 else\
+               self.__pwm_2.get_enabled_pwm()
 
-    def close(self):
+    def close(self, pwm_num: PWMPins):
         """
         Close PWM connection
         Args:
-            N/A
+            pwm_num (PWMPins): target pwm device
         Returns:
             N/A
         """
-        self.pwm.close_pwm()
+        if pwm_num is None:
+            raise ValueError(f"set_config: PWM number is missing {pwm_num}")
+        return self.__pwm_1.close_pwm() if pwm_num == PWMPins.PWM1 else\
+               self.__pwm_2.close_pwm()
 
     def __check_pwm_device_and_instantiate(self, pwm_num: PWMPins):
         # Check if it is first time being called, __pwm

--- a/src/edgepi/pwm/edgepi_pwm.py
+++ b/src/edgepi/pwm/edgepi_pwm.py
@@ -49,7 +49,7 @@ class EdgePiPWM():
             N/A
         """
         if pwm_num is None:
-            raise ValueError(f"set_config: PWM number is missing {pwm_num}")
+            raise ValueError(f"__set_frequency: PWM number is missing {pwm_num}")
         self.__check_range(frequency, PWM_MIN_FREQ, PWM_MAX_FREQ)
 
         self.__pwm_1.set_frequency_pwm(frequency) if pwm_num == PWMPins.PWM1 else\
@@ -64,7 +64,7 @@ class EdgePiPWM():
             frequency (int): frequency value
         """
         if pwm_num is None:
-            raise ValueError(f"set_config: PWM number is missing {pwm_num}")
+            raise ValueError(f"get_frequency: PWM number is missing {pwm_num}")
         return self.__pwm_1.get_frequency_pwm() if pwm_num == PWMPins.PWM1 else\
                self.__pwm_2.get_frequency_pwm()
 
@@ -79,7 +79,7 @@ class EdgePiPWM():
             N/A
         """
         if pwm_num is None:
-            raise ValueError(f"set_config: PWM number is missing {pwm_num}")
+            raise ValueError(f"__set_duty_cycle: PWM number is missing {pwm_num}")
         self.__check_range(duty_cycle, PWM_MIN_DUTY_CYCLE, PWM_MAX_DUTY_CYCLE)
         self.__pwm_1.set_duty_cycle_pwm(duty_cycle/100) if pwm_num == PWMPins.PWM1 else\
         self.__pwm_2.set_duty_cycle_pwm(duty_cycle/100)
@@ -93,7 +93,7 @@ class EdgePiPWM():
             duty_cycle (int): duty_cycle value in percentage
         """
         if pwm_num is None:
-            raise ValueError(f"set_config: PWM number is missing {pwm_num}")
+            raise ValueError(f"get_duty_cycle: PWM number is missing {pwm_num}")
         return self.__pwm_1.get_duty_cycle_pwm()*100 if pwm_num == PWMPins.PWM1 else\
                self.__pwm_2.get_duty_cycle_pwm()*100
 
@@ -107,7 +107,7 @@ class EdgePiPWM():
             N/A
         """
         if pwm_num is None:
-            raise ValueError(f"set_config: PWM number is missing {pwm_num}")
+            raise ValueError(f"__set_polarity: PWM number is missing {pwm_num}")
         self.__pwm_1.set_polarity_pwm(polarity.value) if pwm_num == PWMPins.PWM1 else\
         self.__pwm_2.set_polarity_pwm(polarity.value)
 
@@ -120,7 +120,7 @@ class EdgePiPWM():
             polarity (int): polarity value
         """
         if pwm_num is None:
-            raise ValueError(f"set_config: PWM number is missing {pwm_num}")
+            raise ValueError(f"get_polarity: PWM number is missing {pwm_num}")
         return self.__pwm_1.get_polarity_pwm() if pwm_num == PWMPins.PWM1 else\
                self.__pwm_2.get_polarity_pwm()
 
@@ -134,7 +134,7 @@ class EdgePiPWM():
             N/A
         """
         if pwm_num is None:
-            raise ValueError(f"set_config: PWM number is missing {pwm_num}")
+            raise ValueError(f"enable: PWM number is missing {pwm_num}")
         if self.get_enabled(pwm_num):
             self.disable(pwm_num)
         self.gpio.set_pin_state(GpioPins.AO_EN1.value if pwm_num==PWMPins.PWM1 else\
@@ -155,7 +155,7 @@ class EdgePiPWM():
             N/A
         """
         if pwm_num is None:
-            raise ValueError(f"set_config: PWM number is missing {pwm_num}")
+            raise ValueError(f"disable: PWM number is missing {pwm_num}")
         self.__pwm_1.disable_pwm() if pwm_num == PWMPins.PWM1 else\
         self.__pwm_2.disable_pwm()
         self.gpio.set_pin_state(pwm_num.value)
@@ -169,7 +169,7 @@ class EdgePiPWM():
             enabled (bool): True enabled, False Disabled
         """
         if pwm_num is None:
-            raise ValueError(f"set_config: PWM number is missing {pwm_num}")
+            raise ValueError(f"get_enabled: PWM number is missing {pwm_num}")
         return self.__pwm_1.get_enabled_pwm() if pwm_num == PWMPins.PWM1 else\
                self.__pwm_2.get_enabled_pwm()
 
@@ -182,7 +182,7 @@ class EdgePiPWM():
             N/A
         """
         if pwm_num is None:
-            raise ValueError(f"set_config: PWM number is missing {pwm_num}")
+            raise ValueError(f"close: PWM number is missing {pwm_num}")
         return self.__pwm_1.close_pwm() if pwm_num == PWMPins.PWM1 else\
                self.__pwm_2.close_pwm()
 
@@ -205,17 +205,17 @@ class EdgePiPWM():
             N/A
         """
         if pwm_num is None:
-            raise ValueError(f"set_config: PWM number is missing {pwm_num}")
+            raise ValueError(f"init_pwm: PWM number is missing {pwm_num}")
         pwm_dev = self.__check_pwm_device_and_instantiate(pwm_num)
         if pwm_dev is not None:
             pwm_dev.open_pwm()
-            self.log.debug(f"set_config: Instantiating PWM Device for the first time {pwm_dev.chip}"
+            self.log.debug(f"init_pwm: Instantiating PWM Device for the first time {pwm_dev.chip}"
                            f",{pwm_dev.channel}")
             if pwm_num == PWMPins.PWM1:
                 self.__pwm_1 = pwm_dev
             else:
                 self.__pwm_2 = pwm_dev
-        self.log.debug(f"PWM device is already open")
+        self.log.debug(f"init_pwm: PWM device is already open")
 
     def set_config(self, pwm_num: PWMPins,
                    frequency: int = PWM_MIN_FREQ,
@@ -235,7 +235,7 @@ class EdgePiPWM():
         if pwm_num is None:
             raise ValueError(f"set_config: PWM number is missing {pwm_num}")
         if self.__check_pwm_device_and_instantiate(pwm_num) is not None:
-            raise PwmDeviceError(f"PWM device doesn't exist {pwm_num}, initialize the device first")
+            raise PwmDeviceError(f"set_config: PWM device doesn't exist {pwm_num}, initialize the device first")
         if self.get_frequency(pwm_num) != frequency:
             self.__set_frequency(pwm_num, frequency)
         if self.get_duty_cycle(pwm_num) != duty_cycle:

--- a/src/edgepi/pwm/edgepi_pwm.py
+++ b/src/edgepi/pwm/edgepi_pwm.py
@@ -51,9 +51,10 @@ class EdgePiPWM():
         if pwm_num is None:
             raise ValueError(f"__set_frequency: PWM number is missing {pwm_num}")
         self.__check_range(frequency, PWM_MIN_FREQ, PWM_MAX_FREQ)
-
-        self.__pwm_1.set_frequency_pwm(frequency) if pwm_num == PWMPins.PWM1 else\
-        self.__pwm_2.set_frequency_pwm(frequency)
+        if pwm_num == PWMPins.PWM1:
+            self.__pwm_1.set_frequency_pwm(frequency)
+        else:
+            self.__pwm_2.set_frequency_pwm(frequency)
 
     def get_frequency(self, pwm_num: PWMPins):
         """
@@ -81,8 +82,10 @@ class EdgePiPWM():
         if pwm_num is None:
             raise ValueError(f"__set_duty_cycle: PWM number is missing {pwm_num}")
         self.__check_range(duty_cycle, PWM_MIN_DUTY_CYCLE, PWM_MAX_DUTY_CYCLE)
-        self.__pwm_1.set_duty_cycle_pwm(duty_cycle/100) if pwm_num == PWMPins.PWM1 else\
-        self.__pwm_2.set_duty_cycle_pwm(duty_cycle/100)
+        if pwm_num == PWMPins.PWM1:
+            self.__pwm_1.set_duty_cycle_pwm(duty_cycle/100)
+        else:
+            self.__pwm_2.set_duty_cycle_pwm(duty_cycle/100)
 
     def get_duty_cycle(self, pwm_num: PWMPins):
         """
@@ -108,8 +111,11 @@ class EdgePiPWM():
         """
         if pwm_num is None:
             raise ValueError(f"__set_polarity: PWM number is missing {pwm_num}")
-        self.__pwm_1.set_polarity_pwm(polarity.value) if pwm_num == PWMPins.PWM1 else\
-        self.__pwm_2.set_polarity_pwm(polarity.value)
+        if pwm_num == PWMPins.PWM1:
+            self.__pwm_1.set_polarity_pwm(polarity.value)
+        else:
+            self.__pwm_2.set_polarity_pwm(polarity.value)
+
 
     def get_polarity(self, pwm_num: PWMPins):
         """
@@ -143,8 +149,10 @@ class EdgePiPWM():
                                 GpioPins.DOUT2.value)
         self.gpio.clear_pin_state(pwm_num.value)
         self.log.info("enable: Enabling PWM")
-        self.__pwm_1.enable_pwm() if pwm_num == PWMPins.PWM1 else\
-        self.__pwm_2.enable_pwm()
+        if pwm_num == PWMPins.PWM1:
+            self.__pwm_1.enable_pwm()
+        else:
+            self.__pwm_2.enable_pwm()
 
     def disable(self, pwm_num: PWMPins):
         """
@@ -156,8 +164,10 @@ class EdgePiPWM():
         """
         if pwm_num is None:
             raise ValueError(f"disable: PWM number is missing {pwm_num}")
-        self.__pwm_1.disable_pwm() if pwm_num == PWMPins.PWM1 else\
-        self.__pwm_2.disable_pwm()
+        if pwm_num == PWMPins.PWM1:
+            self.__pwm_1.disable_pwm()
+        else:
+            self.__pwm_2.disable_pwm()
         self.gpio.set_pin_state(pwm_num.value)
 
     def get_enabled(self, pwm_num: PWMPins):
@@ -195,7 +205,7 @@ class EdgePiPWM():
             return PwmDevice(channel=self.__pwm_pin_to_channel[PWMPins.PWM2].value.channel,
                                 chip=self.__pwm_pin_to_channel[PWMPins.PWM2].value.chip)
         return None
-        
+
     def init_pwm(self, pwm_num: PWMPins):
         """
         Initializing and opening PWM device
@@ -215,7 +225,7 @@ class EdgePiPWM():
                 self.__pwm_1 = pwm_dev
             else:
                 self.__pwm_2 = pwm_dev
-        self.log.debug(f"init_pwm: PWM device is already open")
+        self.log.debug("init_pwm: PWM device is already open")
 
     def set_config(self, pwm_num: PWMPins,
                    frequency: int = PWM_MIN_FREQ,
@@ -235,7 +245,8 @@ class EdgePiPWM():
         if pwm_num is None:
             raise ValueError(f"set_config: PWM number is missing {pwm_num}")
         if self.__check_pwm_device_and_instantiate(pwm_num) is not None:
-            raise PwmDeviceError(f"set_config: PWM device doesn't exist {pwm_num}, initialize the device first")
+            raise PwmDeviceError(f"set_config: PWM device doesn't exist {pwm_num},"
+                                 f"initialize the device first")
         if self.get_frequency(pwm_num) != frequency:
             self.__set_frequency(pwm_num, frequency)
         if self.get_duty_cycle(pwm_num) != duty_cycle:

--- a/src/test_edgepi/integration_tests/test_pwm/test_edgepi_pwm.py
+++ b/src/test_edgepi/integration_tests/test_pwm/test_edgepi_pwm.py
@@ -16,7 +16,7 @@ def fixture_test_pwm():
 @pytest.fixture(name="pwm_dev_default")
 def fixture_test_pwm():
     pwm_dev_default = EdgePiPWM()
-    pwm_dev_default.init(PWMPins.PWM1)
+    pwm_dev_default.init_pwm(PWMPins.PWM1)
     pwm_dev_default.set_config(PWMPins.PWM1, 1000, 50, Polarity.NORMAL)
     yield pwm_dev_default
 

--- a/src/test_edgepi/integration_tests/test_pwm/test_edgepi_pwm.py
+++ b/src/test_edgepi/integration_tests/test_pwm/test_edgepi_pwm.py
@@ -10,71 +10,74 @@ _logger = logging.getLogger(__name__)
 
 @pytest.fixture(name="pwm_dev")
 def fixture_test_pwm():
-    pwm_dev = EdgePiPWM(PWMPins.PWM1)
-    pwm_dev.set_frequency(1000)
-    pwm_dev.set_duty_cycle(50)
-    pwm_dev.set_polarity(Polarity.NORMAL)
+    pwm_dev = EdgePiPWM()
     yield pwm_dev
 
-@pytest.mark.parametrize(
-    "pwm_num, result",
-    [
-        (PWMPins.PWM1,
-         [PWMCh.PWM_1.value.channel, PWMCh.PWM_1.value.chip]),
-        (PWMPins.PWM2,
-         [PWMCh.PWM_2.value.channel, PWMCh.PWM_2.value.chip]),
-    ],
-)
-def test_pwm_init(pwm_num, result):
-    pwm_dev = EdgePiPWM(pwm_num=pwm_num)
-    assert pwm_dev.channel == result[0]
-    assert pwm_dev.chip == result[1]
-    pwm_dev.close()
+@pytest.fixture(name="pwm_dev_default")
+def fixture_test_pwm():
+    pwm_dev_default = EdgePiPWM()
+    pwm_dev_default.init(PWMPins.PWM1)
+    pwm_dev_default.set_config(PWMPins.PWM1, 1000, 50, Polarity.NORMAL)
+    yield pwm_dev_default
 
-def test_get_frequency_pwm(pwm_dev):
-    freq = pwm_dev.get_frequency()
+@pytest.mark.parametrize("pwm_num",
+                         [(PWMPins.PWM1),
+                          (PWMPins.PWM2),
+                          ])
+def test_pwm_init(pwm_num, pwm_dev):
+    pwm_dev.init_pwm(pwm_num)
+    if pwm_num == PWMPins.PWM1:
+        assert pwm_dev._EdgePiPWM__pwm_1 is not None
+        assert pwm_dev._EdgePiPWM__pwm_2 is None
+    else:
+        assert pwm_dev._EdgePiPWM__pwm_1 is None
+        assert pwm_dev._EdgePiPWM__pwm_2 is not None
+    pwm_dev.close(pwm_num)
+
+def test_get_frequency_pwm(pwm_dev_default):
+    freq = pwm_dev_default.get_frequency(PWMPins.PWM1)
     assert freq == 1000
-    pwm_dev.close()
+    pwm_dev_default.close(PWMPins.PWM1)
 
 @pytest.mark.parametrize("freq", [(2000)])
-def test_set_frequency_pwm(freq, pwm_dev):
-    init_freq = pwm_dev.get_frequency()
-    pwm_dev.set_frequency(freq)
-    result = pwm_dev.get_frequency()
+def test_set_frequency_pwm(freq, pwm_dev_default):
+    init_freq = pwm_dev_default.get_frequency(PWMPins.PWM1)
+    pwm_dev_default.set_config(pwm_num = PWMPins.PWM1, frequency = freq)
+    result = pwm_dev_default.get_frequency(PWMPins.PWM1)
     assert result != init_freq
-    pwm_dev.close()
+    pwm_dev_default.close(PWMPins.PWM1)
 
-def test_get_duty_cycle_pwm(pwm_dev):
-    duty_cycle = pwm_dev.get_duty_cycle()
+def test_get_duty_cycle_pwm(pwm_dev_default):
+    duty_cycle = pwm_dev_default.get_duty_cycle(PWMPins.PWM1)
     assert duty_cycle == 50
-    pwm_dev.close()
+    pwm_dev_default.close(PWMPins.PWM1)
 
-def test_set_duty_cycle_pwm(pwm_dev):
-    init_duty_cycle = pwm_dev.get_duty_cycle()
-    pwm_dev.set_duty_cycle(60)
-    result = pwm_dev.get_duty_cycle()
+def test_set_duty_cycle_pwm(pwm_dev_default):
+    init_duty_cycle = pwm_dev_default.get_duty_cycle(PWMPins.PWM1)
+    pwm_dev_default.set_config(pwm_num = PWMPins.PWM1, duty_cycle=60)
+    result = pwm_dev_default.get_duty_cycle(PWMPins.PWM1)
     assert result != init_duty_cycle
-    pwm_dev.close()
+    pwm_dev_default.close(PWMPins.PWM1)
 
-def test_get_polarity_pwm(pwm_dev):
-    pol = pwm_dev.get_polarity()
+def test_get_polarity_pwm(pwm_dev_default):
+    pol = pwm_dev_default.get_polarity(PWMPins.PWM1)
     assert pol == Polarity.NORMAL.value
-    pwm_dev.close()
+    pwm_dev_default.close(PWMPins.PWM1)
 
-def test_set_polarity_pwm(pwm_dev):
-    init_pol = pwm_dev.get_polarity()
-    pwm_dev.set_polarity(Polarity.INVERSED)
-    result = pwm_dev.get_polarity()
+def test_set_polarity_pwm(pwm_dev_default):
+    init_pol = pwm_dev_default.get_polarity()
+    pwm_dev_default.set_config(pwm_num = PWMPins.PWM1, polarity = Polarity.INVERSED)
+    result = pwm_dev_default.get_polarity()
     assert result != init_pol
-    pwm_dev.close()
+    pwm_dev_default.close(PWMPins.PWM1)
 
-def test_enable(pwm_dev):
-    pwm_dev.enable()
-    assert pwm_dev.get_enabled() is True
-    pwm_dev.close()
+def test_enable(pwm_dev_default):
+    pwm_dev_default.enable(PWMPins.PWM1)
+    assert pwm_dev_default.get_enabled(PWMPins.PWM1) is True
+    pwm_dev_default.close(PWMPins.PWM1)
 
 
-def test_disable(pwm_dev):
-    pwm_dev.disable()
-    assert pwm_dev.get_enabled() is False
-    pwm_dev.close()
+def test_disable(pwm_dev_default):
+    pwm_dev_default.disable(PWMPins.PWM1)
+    assert pwm_dev_default.get_enabled(PWMPins.PWM1) is False
+    pwm_dev_default.close(PWMPins.PWM1)

--- a/src/test_edgepi/integration_tests/test_pwm/test_edgepi_pwm.py
+++ b/src/test_edgepi/integration_tests/test_pwm/test_edgepi_pwm.py
@@ -12,7 +12,7 @@ def fixture_test_pwm():
     yield pwm_dev
 
 @pytest.fixture(name="pwm_dev_default")
-def fixture_test_pwm():
+def fixture_test_pwm_def():
     pwm_dev_default = EdgePiPWM()
     pwm_dev_default.init_pwm(PWMPins.PWM1)
     pwm_dev_default.set_config(PWMPins.PWM1, 1000, 50, Polarity.NORMAL)

--- a/src/test_edgepi/integration_tests/test_pwm/test_edgepi_pwm.py
+++ b/src/test_edgepi/integration_tests/test_pwm/test_edgepi_pwm.py
@@ -21,11 +21,11 @@ def test_pwm_init(pwm_num):
     pwm_dev = EdgePiPWM()
     pwm_dev.init_pwm(pwm_num)
     if pwm_num == PWMPins.PWM1:
-        assert pwm_dev.__pwm_devs[pwm_num] is not None
-        assert pwm_dev.__pwm_devs[PWMPins.PWM2] is None
+        assert pwm_dev._EdgePiPWM__pwm_devs[pwm_num] is not None
+        assert pwm_dev._EdgePiPWM__pwm_devs[PWMPins.PWM2] is None
     else:
-        assert pwm_dev.__pwm_devs[pwm_num] is not None
-        assert pwm_dev.__pwm_devs[PWMPins.PWM1] is None
+        assert pwm_dev._EdgePiPWM__pwm_devs[pwm_num] is not None
+        assert pwm_dev._EdgePiPWM__pwm_devs[PWMPins.PWM1] is None
     pwm_dev.close(pwm_num)
 
 def test_get_frequency_pwm(pwm_dev_default):

--- a/src/test_edgepi/integration_tests/test_pwm/test_edgepi_pwm.py
+++ b/src/test_edgepi/integration_tests/test_pwm/test_edgepi_pwm.py
@@ -3,10 +3,8 @@
 import logging
 import pytest
 
-from edgepi.pwm.pwm_constants import PWMCh, Polarity, PWMPins
+from edgepi.pwm.pwm_constants import Polarity, PWMPins
 from edgepi.pwm.edgepi_pwm import EdgePiPWM
-
-_logger = logging.getLogger(__name__)
 
 @pytest.fixture(name="pwm_dev")
 def fixture_test_pwm():
@@ -65,9 +63,9 @@ def test_get_polarity_pwm(pwm_dev_default):
     pwm_dev_default.close(PWMPins.PWM1)
 
 def test_set_polarity_pwm(pwm_dev_default):
-    init_pol = pwm_dev_default.get_polarity()
+    init_pol = pwm_dev_default.get_polarity(PWMPins.PWM1)
     pwm_dev_default.set_config(pwm_num = PWMPins.PWM1, polarity = Polarity.INVERSED)
-    result = pwm_dev_default.get_polarity()
+    result = pwm_dev_default.get_polarity(PWMPins.PWM1)
     assert result != init_pol
     pwm_dev_default.close(PWMPins.PWM1)
 

--- a/src/test_edgepi/integration_tests/test_pwm/test_edgepi_pwm.py
+++ b/src/test_edgepi/integration_tests/test_pwm/test_edgepi_pwm.py
@@ -5,11 +5,6 @@ import pytest
 from edgepi.pwm.pwm_constants import Polarity, PWMPins
 from edgepi.pwm.edgepi_pwm import EdgePiPWM
 
-@pytest.fixture(name="pwm_dev")
-def fixture_test_pwm():
-    pwm_dev = EdgePiPWM()
-    yield pwm_dev
-
 @pytest.fixture(name="pwm_dev_default")
 def fixture_test_pwm_def():
     pwm_dev_default = EdgePiPWM()
@@ -21,15 +16,16 @@ def fixture_test_pwm_def():
                          [(PWMPins.PWM1),
                           (PWMPins.PWM2),
                           ])
-def test_pwm_init(pwm_num, pwm_dev):
+def test_pwm_init(pwm_num):
     # pylint: disable=protected-access
+    pwm_dev = EdgePiPWM()
     pwm_dev.init_pwm(pwm_num)
     if pwm_num == PWMPins.PWM1:
-        assert pwm_dev._EdgePiPWM__pwm_1 is not None
-        assert pwm_dev._EdgePiPWM__pwm_2 is None
+        assert pwm_dev.__pwm_devs[pwm_num] is not None
+        assert pwm_dev.__pwm_devs[PWMPins.PWM2] is None
     else:
-        assert pwm_dev._EdgePiPWM__pwm_1 is None
-        assert pwm_dev._EdgePiPWM__pwm_2 is not None
+        assert pwm_dev.__pwm_devs[pwm_num] is not None
+        assert pwm_dev.__pwm_devs[PWMPins.PWM1] is None
     pwm_dev.close(pwm_num)
 
 def test_get_frequency_pwm(pwm_dev_default):

--- a/src/test_edgepi/integration_tests/test_pwm/test_edgepi_pwm.py
+++ b/src/test_edgepi/integration_tests/test_pwm/test_edgepi_pwm.py
@@ -1,6 +1,5 @@
 """EdgePi PWM integration test"""
 
-import logging
 import pytest
 
 from edgepi.pwm.pwm_constants import Polarity, PWMPins
@@ -23,6 +22,7 @@ def fixture_test_pwm_def():
                           (PWMPins.PWM2),
                           ])
 def test_pwm_init(pwm_num, pwm_dev):
+    # pylint: disable=protected-access
     pwm_dev.init_pwm(pwm_num)
     if pwm_num == PWMPins.PWM1:
         assert pwm_dev._EdgePiPWM__pwm_1 is not None


### PR DESCRIPTION
Closes #315 
PWM refactor

- init_pwm() method to instantiate and open a pwm device
- set_conifg() set pwm parameters
- enable() refactored to always enable the signal