### PR TITLE
reverting voltage_to_code for differential reading

### DIFF
--- a/src/edgepi/adc/adc_voltage.py
+++ b/src/edgepi/adc/adc_voltage.py
@@ -73,14 +73,8 @@ def code_to_voltage(code: list[int], adc_info: ADCReadInfo, calibs: CalibParam) 
     num_bits = adc_info.num_data_bytes * 8
     code_val = code_bits.uint
 
-    if _is_negative_voltage(code_bits) and adc_info.num_data_bytes == ADC1_NUM_DATA_BYTES:
-        code_val = code_val - ADC1_UPPER_LIMIT
-    elif _is_negative_voltage(code_bits) and adc_info.num_data_bytes == ADC2_NUM_DATA_BYTES:
-        code_val = code_val - ADC2_UPPER_LIMIT
-    elif adc_info.num_data_bytes == ADC1_NUM_DATA_BYTES:
-        code_val = code_val + ADC1_UPPER_LIMIT
-    elif adc_info.num_data_bytes == ADC2_NUM_DATA_BYTES:
-        code_val = code_val + ADC2_UPPER_LIMIT
+    if _is_negative_voltage(code_bits):
+        code_val = code_val - 2**num_bits
 
     v_in = _code_to_input_voltage(code_val, REFERENCE_VOLTAGE, num_bits)
 

--- a/src/test_edgepi/unit_tests/test_adc/test_adc_voltage.py
+++ b/src/test_edgepi/unit_tests/test_adc/test_adc_voltage.py
@@ -84,17 +84,17 @@ def test__adc_voltage_to_input_voltage(voltage, gain, offset, result):
 @pytest.mark.parametrize(
     "code, adc_num, calibs, result",
     [
-        ([0x00, 0x00, 0x00, 0x00], ADCNum.ADC_1.value,CalibParam(gain=1, offset=0.0), 12.069),
-        ([0x7F, 0xFF, 0xFF, 0xFF], ADCNum.ADC_1.value,CalibParam(gain=1, offset=0.0), 24.138),
-        ([0x80, 0x00, 0x00, 0x00], ADCNum.ADC_1.value,CalibParam(gain=1, offset=0.0), 0.00),
-        ([0x00, 0x00, 0x00, 0x00], ADCNum.ADC_1.value,CalibParam(gain=1, offset=0.0), 12.069),
-        ([0x00, 0x00, 0x00, 0x00], ADCNum.ADC_1.value,CalibParam(gain=1, offset=0.0), 12.069),
-        ([0x00, 0x00, 0x00, 0x00], ADCNum.ADC_2.value,CalibParam(gain=1, offset=0.0), 12.069),
-        ([0x7F, 0xFF, 0xFF, 0xFF], ADCNum.ADC_2.value,CalibParam(gain=1, offset=0.0), 24.138),
-        ([0x7F, 0xFF, 0xFF, 0x00], ADCNum.ADC_2.value,CalibParam(gain=1, offset=0.0), 24.138),
-        ([0x80, 0x00, 0x00, 0xFF], ADCNum.ADC_2.value,CalibParam(gain=1, offset=0.0), 0.00),
-        ([0x80, 0x00, 0x00, 0x00], ADCNum.ADC_2.value,CalibParam(gain=1, offset=0.0), 0.00),
-        ([0x00, 0x00, 0x00, 0x00], ADCNum.ADC_2.value,CalibParam(gain=1, offset=0.0), 12.069),
+        ([0x00, 0x00, 0x00, 0x00], ADCNum.ADC_1.value,CalibParam(gain=1, offset=0.0), 0),
+        ([0x7F, 0xFF, 0xFF, 0xFF], ADCNum.ADC_1.value,CalibParam(gain=1, offset=0.0), 12.069),
+        ([0x80, 0x00, 0x00, 0x00], ADCNum.ADC_1.value,CalibParam(gain=1, offset=0.0), -12.069),
+        ([0x00, 0x00, 0x00, 0x00], ADCNum.ADC_1.value,CalibParam(gain=1, offset=0.0), 0),
+        ([0x00, 0x00, 0x00, 0x00], ADCNum.ADC_1.value,CalibParam(gain=1, offset=0.0), 0),
+        ([0x00, 0x00, 0x00, 0x00], ADCNum.ADC_2.value,CalibParam(gain=1, offset=0.0), 0),
+        ([0x7F, 0xFF, 0xFF, 0xFF], ADCNum.ADC_2.value,CalibParam(gain=1, offset=0.0), 12.069),
+        ([0x7F, 0xFF, 0xFF, 0x00], ADCNum.ADC_2.value,CalibParam(gain=1, offset=0.0), 12.069),
+        ([0x80, 0x00, 0x00, 0xFF], ADCNum.ADC_2.value,CalibParam(gain=1, offset=0.0), -12.069),
+        ([0x80, 0x00, 0x00, 0x00], ADCNum.ADC_2.value,CalibParam(gain=1, offset=0.0), -12.069),
+        ([0x00, 0x00, 0x00, 0x00], ADCNum.ADC_2.value,CalibParam(gain=1, offset=0.0), 0),
     ],
 )
 def test_code_to_voltage(code, adc_num, calibs, result):


### PR DESCRIPTION
Reverting thecode_to_voltage method back to previous version, previous change broke the differential measurements

#384 