### PR TITLE
bypassing PGA

### DIFF
--- a/src/edgepi/adc/adc_constants.py
+++ b/src/edgepi/adc/adc_constants.py
@@ -190,7 +190,12 @@ class ADCMasks(Enum):
     ADC2_DR_BITS = 0x3F  # overwrite bits 7:6
     RMUXP_BITS = 0xC7  # overwrite bits 5:3
     RMUXN_BITS = 0xF8  # overwrite bits 2:0
+    PGA_BITS = 0x7F # overwrite bit 7
 
+class ADC1PGA(Enum):
+    """ADS1263 PGA Enable bypass ADC1"""
+    ENABLED = OpCode(0x00, ADCReg.REG_MODE2.value, ADCMasks.PGA_BITS.value)
+    BYPASSED = OpCode(0x80, ADCReg.REG_MODE2.value, ADCMasks.PGA_BITS.value)
 
 class ADC2DataRate(Enum):
     """ADS1263 data rates for ADC2"""

--- a/src/edgepi/adc/edgepi_adc.py
+++ b/src/edgepi/adc/edgepi_adc.py
@@ -10,6 +10,7 @@ from edgepi.calibration.calibration_constants import CalibParam
 from edgepi.peripherals.spi import SpiDevice as SPI
 from edgepi.adc.adc_commands import ADCCommands
 from edgepi.adc.adc_constants import (
+    ADC1PGA,
     ADC1DataRate,
     ADC2DataRate,
     ADCChannel as CH,
@@ -128,7 +129,7 @@ class EdgePiADC(SPI):
         # ADC always needs to be in CRC check mode. This also updates the internal __state.
         # If this call to __config is removed, replace with a call to get_register_map to
         # initialize __state.
-        self.__config(checksum_mode=CheckMode.CHECK_BYTE_CRC)
+        self.__config(checksum_mode=CheckMode.CHECK_BYTE_CRC, adc_1_pga=ADC1PGA.BYPASSED)
         # TODO: adc reference should ba a config that customer passes depending on the range of
         # voltage they are measuring. To be changed later when range config is implemented
         # self.set_adc_reference(ADCReferenceSwitching.GND_SW1.value)
@@ -823,6 +824,7 @@ class EdgePiADC(SPI):
         adc_2_mux_n: CH = None,
         adc_1_data_rate: ADC1DataRate = None,
         adc_2_data_rate: ADC2DataRate = None,
+        adc_1_pga: ADC1PGA = None,
         filter_mode: FilterMode = None,
         conversion_mode: ConvMode = None,
         checksum_mode: CheckMode = None,

--- a/src/test_edgepi/integration_tests/test_adc/test_adc.py
+++ b/src/test_edgepi/integration_tests/test_adc/test_adc.py
@@ -18,6 +18,7 @@ from edgepi.adc.adc_constants import (
     REFMUX,
     DiffMode,
     RTDModes,
+    ADC1PGA,
 )
 from edgepi.adc.edgepi_adc import EdgePiADC
 
@@ -732,6 +733,14 @@ def fixture_adc():
             },
             {
                 ADCReg.REG_REFMUX.value: 0x0,
+            },
+        ),
+        (
+            {
+                "adc_1_pga": ADC1PGA.BYPASSED
+            },
+            {
+                ADCReg.REG_MODE2.value: 0x84,
             },
         ),
     ],

--- a/src/test_edgepi/unit_tests/test_adc/test_edgepi_adc.py
+++ b/src/test_edgepi/unit_tests/test_adc/test_edgepi_adc.py
@@ -30,6 +30,7 @@ from edgepi.adc.adc_constants import (
     ADC1DataRate,
     ADC2DataRate,
     FilterMode,
+    ADC1PGA,
 )
 from edgepi.reg_helper.reg_helper import OpCode, BitMask
 from edgepi.calibration.calibration_constants import CalibParam
@@ -335,6 +336,16 @@ def test_read_registers_to_map(mocker, adc):
             {ADCReg.REG_REFMUX.value: 0x3F},
             {"pos_ref_inp": REFMUX.POS_REF_INT_VAVDD, "neg_ref_inp": REFMUX.NEG_REF_INT_VAVSS},
             {ADCReg.REG_REFMUX.value: 0b00100100},
+        ),
+        (
+            {ADCReg.REG_MODE2.value: 0x0F},
+            {"adc_1_pga": ADC1PGA.BYPASSED},
+            {ADCReg.REG_MODE2.value: 0x8F}
+        ),
+        (
+            {ADCReg.REG_MODE2.value: 0x8F},
+            {"adc_1_pga": ADC1PGA.ENABLED},
+            {ADCReg.REG_MODE2.value: 0x0F}
         ),
     ],
 )


### PR DESCRIPTION
#384 
PGA setting also contributes to the offset. Bypassing the PGA by default.
- added PGA setting config parameter
- added the parameter to the initial config along side with CRC, because PGA is enabled by default but we want it to be bypassed