### PR TITLE
Dev thread safe pwm

### DIFF
--- a/src/edgepi/pwm/edgepi_pwm.py
+++ b/src/edgepi/pwm/edgepi_pwm.py
@@ -183,8 +183,12 @@ class EdgePiPWM():
         if pwm_num is None or pwm_num not in EdgePiPWM.__pwm_devs:
             raise ValueError(f"close: PWM number is missing {pwm_num}")
         with EdgePiPWM.__lock_pwm[pwm_num]:
-            EdgePiPWM.__pwm_devs[pwm_num].close_pwm()
-            EdgePiPWM.__pwm_devs[pwm_num] = None
+            try:
+                EdgePiPWM.__pwm_devs[pwm_num].close_pwm()
+            except Exception as exc:
+                raise OSError(f"Failed to close {pwm_num}") from exc
+            finally:
+                EdgePiPWM.__pwm_devs[pwm_num] = None
 
     def __init_pwm_dev(self, pwm_num: PWMPins):
         EdgePiPWM.__pwm_devs[pwm_num]=PwmDevice(

--- a/src/edgepi/pwm/edgepi_pwm.py
+++ b/src/edgepi/pwm/edgepi_pwm.py
@@ -229,7 +229,7 @@ class EdgePiPWM():
         """
         if pwm_num is None:
             raise ValueError(f"set_config: PWM number is missing {pwm_num}")
-        
+
         with EdgePiPWM.__lock_pwm[pwm_num]:
             if EdgePiPWM.__pwm_devs[pwm_num] is None:
                 raise PwmDeviceError(f"set_config: PWM device doesn't exist {pwm_num},"

--- a/src/test_edgepi/integration_tests/test_pwm/test_edgepi_pwm_concurrency.py
+++ b/src/test_edgepi/integration_tests/test_pwm/test_edgepi_pwm_concurrency.py
@@ -1,0 +1,67 @@
+""" Integration test for peripheral concurrency """
+
+import threading
+import logging
+import pytest
+
+from edgepi.pwm.pwm_constants import Polarity, PWMPins
+from edgepi.pwm.edgepi_pwm import EdgePiPWM
+
+_logger = logging.getLogger(__name__)
+
+class PropagatingThread(threading.Thread):
+    """Propagating thread to raise exceptions in calling function"""
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.exc = None
+
+    def run(self):
+        self.exc = None
+        try:
+            super().run()
+        # pylint:disable=broad-exception-caught
+        except Exception as err:
+            self.exc = err
+
+    def join(self, *args, **kwargs):
+        super().join(*args, **kwargs)
+        if self.exc:
+            raise self.exc
+
+@pytest.fixture(name="pwm_dev")
+def fixture_test_pwm():
+    pwm_dev = EdgePiPWM()
+    yield pwm_dev
+
+def pwm_open_set_config_close(pwm):
+    """PWM init, setconfig and close"""
+    pwm.init_pwm(PWMPins.PWM1)
+    pwm.set_config(PWMPins.PWM1, frequency=1000, duty_cycle=0.5, polarity=Polarity.NORMAL)
+    # pwm.close(PWMPins.PWM1)
+
+#pylint:disable=unused-argument
+@pytest.mark.parametrize("iteration", range(10))
+def test_pwm_concurrency_shared(iteration, pwm_dev):
+    """Test for PWM concurrency bug"""
+    threads = [PropagatingThread(target=pwm_open_set_config_close(pwm_dev)) for _ in range(100)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+def pwm_open_set_config_close_indiv():
+    """PWM init, setconfig and close"""
+    pwm = EdgePiPWM()
+    pwm.init_pwm(PWMPins.PWM1)
+    pwm.set_config(PWMPins.PWM1, frequency=1000, duty_cycle=0.5, polarity=Polarity.NORMAL)
+    # pwm.close(PWMPins.PWM1)
+
+#pylint:disable=unused-argument
+@pytest.mark.parametrize("iteration", range(10))
+def test_pwm_concurrency_indiv(iteration):
+    """Test for pwm concurrency bug"""
+    threads = [PropagatingThread(target=pwm_open_set_config_close_indiv()) for _ in range(100)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()

--- a/src/test_edgepi/unit_tests/test_pwm/test_edgepi_pwm.py
+++ b/src/test_edgepi/unit_tests/test_pwm/test_edgepi_pwm.py
@@ -101,6 +101,18 @@ def test_pwm_close(mocker, pwm_num, error, pwm_dev):
         mock_pwmdevice.close_pwm.assert_called_once()
         assert pwm_dev._EdgePiPWM__pwm_devs[pwm_num] is None
 
+@pytest.mark.parametrize("pwm_num, error",
+                         [(PWMPins.PWM1, pytest.raises(OSError)),
+                          (PWMPins.PWM2, pytest.raises(OSError)),
+                          ])
+def test_pwm_close_with_exception(mocker, pwm_num, error, pwm_dev):
+    mock_pwmdevice= mocker.patch("edgepi.peripherals.pwm.PwmDevice")
+    mocker.patch("edgepi.peripherals.pwm.PwmDevice.close_pwm", side_effect=Exception)
+    pwm_dev._EdgePiPWM__pwm_devs[pwm_num] = mock_pwmdevice
+    with error:
+        pwm_dev.close(pwm_num)
+        mock_pwmdevice.close_pwm.assert_called_once()
+        assert pwm_dev._EdgePiPWM__pwm_devs[pwm_num] is None
 
 @pytest.mark.parametrize("pwm_num ,expected, error",
                          [(PWMPins.PWM1, 1000.0, does_not_raise()),

--- a/src/test_edgepi/unit_tests/test_pwm/test_edgepi_pwm.py
+++ b/src/test_edgepi/unit_tests/test_pwm/test_edgepi_pwm.py
@@ -316,9 +316,11 @@ def test_set_config(mocker, params, pwm_dev):
     mock_set_freq = mocker.patch("edgepi.pwm.edgepi_pwm.EdgePiPWM._EdgePiPWM__set_frequency")
     mock_set_duty = mocker.patch("edgepi.pwm.edgepi_pwm.EdgePiPWM._EdgePiPWM__set_duty_cycle")
     mock_set_pol = mocker.patch("edgepi.pwm.edgepi_pwm.EdgePiPWM._EdgePiPWM__set_polarity")
+    mock_lock = mocker.patch("edgepi.pwm.edgepi_pwm.EdgePiPWM._EdgePiPWM__lock_pwm")
     mock_pwmdevice= mocker.patch("edgepi.peripherals.pwm.PwmDevice")
     pwm_dev._EdgePiPWM__pwm_devs[params[0]] = mock_pwmdevice
     pwm_dev.set_config(params[0], params[1], params[2], params[3])
+    assert len(mock_lock.mock_calls)==3
     if params[1] is not None:
         mock_set_freq.assert_called_once_with(params[0],params[1])
     else:


### PR DESCRIPTION
theading lock is implemented little differently in PWM module. This is due to how the difference in operation. Unlike other peripherals, PWM file has to be open for the duration of its usage. The init_pwm() method already has checking for whether it's already open or not by using __pwm_dev dictionary defined as class variable. However, close() and set_config method require a locking.

- This PR implements the thread lock for both PWM1 and PWM2. 
- Moved __pwm_dev dictionary to class variable