### PR TITLE
Dev pwm #401

### DIFF
--- a/src/edgepi/pwm/edgepi_pwm.py
+++ b/src/edgepi/pwm/edgepi_pwm.py
@@ -68,6 +68,8 @@ class EdgePiPWM():
         """
         if pwm_num is None or pwm_num not in EdgePiPWM.__pwm_devs:
             raise ValueError(f"get_frequency: PWM number is missing {pwm_num}")
+        if EdgePiPWM.__pwm_devs[pwm_num] is None:
+            raise PwmDeviceError(f"get_frequency:{pwm_num} not initialized")
         return EdgePiPWM.__pwm_devs[pwm_num].get_frequency_pwm()
 
     def __set_duty_cycle(self, pwm_num: PWMPins, duty_cycle: float):
@@ -95,6 +97,8 @@ class EdgePiPWM():
         """
         if pwm_num is None or pwm_num not in EdgePiPWM.__pwm_devs:
             raise ValueError(f"get_duty_cycle: PWM number is missing {pwm_num}")
+        if EdgePiPWM.__pwm_devs[pwm_num] is None:
+            raise PwmDeviceError(f"get_frequency:{pwm_num} not initialized")
         return EdgePiPWM.__pwm_devs[pwm_num].get_duty_cycle_pwm()
 
     def __set_polarity(self, pwm_num: PWMPins, polarity: Polarity):
@@ -120,6 +124,8 @@ class EdgePiPWM():
         """
         if pwm_num is None or pwm_num not in EdgePiPWM.__pwm_devs:
             raise ValueError(f"get_polarity: PWM number is missing {pwm_num}")
+        if EdgePiPWM.__pwm_devs[pwm_num] is None:
+            raise PwmDeviceError(f"get_frequency:{pwm_num} not initialized")
         return EdgePiPWM.__pwm_devs[pwm_num].get_polarity_pwm()
 
 
@@ -133,6 +139,8 @@ class EdgePiPWM():
         """
         if pwm_num is None or pwm_num not in EdgePiPWM.__pwm_devs:
             raise ValueError(f"enable: PWM number is missing {pwm_num}")
+        if EdgePiPWM.__pwm_devs[pwm_num] is None:
+            raise PwmDeviceError(f"get_frequency:{pwm_num} not initialized")
         if self.get_enabled(pwm_num):
             self.disable(pwm_num)
         self.gpio.set_pin_state(GpioPins.AO_EN1.value if pwm_num==PWMPins.PWM1 else\
@@ -153,6 +161,8 @@ class EdgePiPWM():
         """
         if pwm_num is None or pwm_num not in EdgePiPWM.__pwm_devs:
             raise ValueError(f"disable: PWM number is missing {pwm_num}")
+        if EdgePiPWM.__pwm_devs[pwm_num] is None:
+            raise PwmDeviceError(f"get_frequency:{pwm_num} not initialized")
         EdgePiPWM.__pwm_devs[pwm_num].disable_pwm()
         self.gpio.set_pin_state(GpioPins.AO_EN1.value if pwm_num==PWMPins.PWM1 else\
                                 GpioPins.AO_EN2.value)
@@ -170,6 +180,8 @@ class EdgePiPWM():
         """
         if pwm_num is None or pwm_num not in EdgePiPWM.__pwm_devs:
             raise ValueError(f"get_enabled: PWM number is missing {pwm_num}")
+        if EdgePiPWM.__pwm_devs[pwm_num] is None:
+            raise PwmDeviceError(f"get_frequency:{pwm_num} not initialized")
         return EdgePiPWM.__pwm_devs[pwm_num].get_enabled_pwm()
 
     def close(self, pwm_num: PWMPins):
@@ -237,10 +249,14 @@ class EdgePiPWM():
         with EdgePiPWM.__lock_pwm[pwm_num]:
             if EdgePiPWM.__pwm_devs[pwm_num] is None:
                 raise PwmDeviceError(f"set_config: PWM device doesn't exist {pwm_num},"
-                                 f"initialize the device first")
-            if frequency is not None:
-                self.__set_frequency(pwm_num, frequency)
-            if  duty_cycle is not None:
-                self.__set_duty_cycle(pwm_num, duty_cycle)
-            if polarity is not None:
-                self.__set_polarity(pwm_num, polarity)
+                                     f"initialize the device first")
+            try:
+                if frequency is not None:
+                    self.__set_frequency(pwm_num, frequency)
+                if  duty_cycle is not None:
+                    self.__set_duty_cycle(pwm_num, duty_cycle)
+                if polarity is not None:
+                    self.__set_polarity(pwm_num, polarity)
+            except Exception as exc:
+                raise PwmDeviceError (f"set_config: PWM device doesn't exist {pwm_num},"
+                                      f"initialize the device first") from exc

--- a/src/test_edgepi/integration_tests/test_pwm/test_edgepi_pwm_concurrency.py
+++ b/src/test_edgepi/integration_tests/test_pwm/test_edgepi_pwm_concurrency.py
@@ -37,6 +37,7 @@ def pwm_open_set_config(pwm):
     """PWM init, setconfig and close"""
     pwm.init_pwm(PWMPins.PWM1)
     pwm.set_config(PWMPins.PWM1, frequency=1000, duty_cycle=0.5, polarity=Polarity.NORMAL)
+    pwm.close(PWMPins.PWM1)
 
 def pwm_open_set_config_close(pwm):
     """PWM init, setconfig and close"""
@@ -48,16 +49,16 @@ def pwm_open_set_config_close(pwm):
 @pytest.mark.parametrize("iteration", range(10))
 def test_pwm_concurrency_shared(iteration, pwm_dev):
     """Test for PWM concurrency bug"""
-    threads = [PropagatingThread(target=pwm_open_set_config(pwm_dev)) for _ in range(100)]
+    threads = [PropagatingThread(target=pwm_open_set_config(pwm_dev)) for _ in range(10)]
     for thread in threads:
         thread.start()
     for thread in threads:
         thread.join()
 
-@pytest.mark.parametrize("iteration, error", (range(10), pytest.raises(PwmDeviceError)))
-def test_pwm_concurrency_shared_error(iteration, error, pwm_dev):
+@pytest.mark.parametrize("iteration", range(10))
+def test_pwm_concurrency_shared_error(iteration, pwm_dev):
     """Test for PWM concurrency bug"""
-    with error:
+    with pytest.raises(PwmDeviceError):
         threads = [PropagatingThread(target=pwm_open_set_config_close(pwm_dev)) for _ in range(100)]
         for thread in threads:
             thread.start()
@@ -78,10 +79,10 @@ def pwm_open_set_config_close_indiv():
     pwm.close(PWMPins.PWM1)
 
 #pylint:disable=unused-argument
-@pytest.mark.parametrize("iteration, error", (range(10), pytest.raises(PwmDeviceError)))
-def test_pwm_concurrency_indiv(iteration, error):
+@pytest.mark.parametrize("iteration", range(10))
+def test_pwm_concurrency_close_indiv(iteration):
     """Test for pwm concurrency bug"""
-    with error:
+    with pytest.raises(PwmDeviceError):
         threads = [PropagatingThread(target=pwm_open_set_config_close_indiv()) for _ in range(100)]
         for thread in threads:
             thread.start()

--- a/src/test_edgepi/integration_tests/test_pwm/test_edgepi_pwm_concurrency.py
+++ b/src/test_edgepi/integration_tests/test_pwm/test_edgepi_pwm_concurrency.py
@@ -34,16 +34,17 @@ def fixture_test_pwm():
     yield pwm_dev
 
 def pwm_open_set_config(pwm):
-    """PWM init, setconfig and close"""
+    """PWM init, setconfig"""
     pwm.init_pwm(PWMPins.PWM1)
     pwm.set_config(PWMPins.PWM1, frequency=1000, duty_cycle=0.5, polarity=Polarity.NORMAL)
 
 def pwm_open_close(pwm):
-    """PWM init, setconfig and close"""
+    """PWM init and close"""
     pwm.init_pwm(PWMPins.PWM1)
     pwm.close(PWMPins.PWM1)
 
 def pwm_set_config(pwm):
+    """PWM setconfig"""
     pwm.set_config(PWMPins.PWM1, frequency=1000, duty_cycle=0.5, polarity=Polarity.NORMAL)
 
 #pylint:disable=unused-argument
@@ -62,26 +63,27 @@ def test_pwm_concurrency_shared_error(iteration, pwm_dev):
     with pytest.raises(PwmDeviceError):
         threads_open_close = [PropagatingThread(target=pwm_open_close(pwm_dev)) for _ in range(10)]
         threads_set_config = [PropagatingThread(target=pwm_set_config(pwm_dev)) for _ in range(10)]
-        for indx in range(len(threads_open_close)):
+        for _, indx in enumerate(threads_open_close):
             threads_open_close[indx].start()
             threads_set_config[indx].start()
-        for indx in range(len(threads_open_close)):
+        for _, indx in enumerate(threads_open_close):
             threads_open_close[indx].join()
             threads_set_config[indx].join()
 
 def pwm_open_set_config_indiv():
-    """PWM init, setconfig and close"""
+    """PWM init, setconfig """
     pwm = EdgePiPWM()
     pwm.init_pwm(PWMPins.PWM1)
     pwm.set_config(PWMPins.PWM1, frequency=1000, duty_cycle=0.5, polarity=Polarity.NORMAL)
 
 def pwm_open_close_indiv():
-    """PWM init, setconfig and close"""
+    """PWM init close"""
     pwm = EdgePiPWM()
     pwm.init_pwm(PWMPins.PWM1)
     pwm.close(PWMPins.PWM1)
 
 def pwm_set_config_indiv():
+    """PWM setconfig"""
     pwm = EdgePiPWM()
     pwm.set_config(PWMPins.PWM1, frequency=1000, duty_cycle=0.5, polarity=Polarity.NORMAL)
 
@@ -93,10 +95,10 @@ def test_pwm_concurrency_close_indiv_error(iteration):
     with pytest.raises(PwmDeviceError):
         threads_open_close = [PropagatingThread(target=pwm_open_close_indiv()) for _ in range(10)]
         threads_set_config = [PropagatingThread(target=pwm_set_config_indiv()) for _ in range(10)]
-        for indx in range(len(threads_open_close)):
+        for _, indx in enumerate(threads_open_close):
             threads_open_close[indx].start()
             threads_set_config[indx].start()
-        for indx in range(len(threads_open_close)):
+        for _, indx in enumerate(threads_open_close):
             threads_open_close[indx].join()
             threads_set_config[indx].join()
 

--- a/src/test_edgepi/integration_tests/test_pwm/test_edgepi_pwm_concurrency.py
+++ b/src/test_edgepi/integration_tests/test_pwm/test_edgepi_pwm_concurrency.py
@@ -37,13 +37,14 @@ def pwm_open_set_config(pwm):
     """PWM init, setconfig and close"""
     pwm.init_pwm(PWMPins.PWM1)
     pwm.set_config(PWMPins.PWM1, frequency=1000, duty_cycle=0.5, polarity=Polarity.NORMAL)
-    pwm.close(PWMPins.PWM1)
 
-def pwm_open_set_config_close(pwm):
+def pwm_open_close(pwm):
     """PWM init, setconfig and close"""
     pwm.init_pwm(PWMPins.PWM1)
-    pwm.set_config(PWMPins.PWM1, frequency=1000, duty_cycle=0.5, polarity=Polarity.NORMAL)
     pwm.close(PWMPins.PWM1)
+
+def pwm_set_config(pwm):
+    pwm.set_config(PWMPins.PWM1, frequency=1000, duty_cycle=0.5, polarity=Polarity.NORMAL)
 
 #pylint:disable=unused-argument
 @pytest.mark.parametrize("iteration", range(10))
@@ -59,11 +60,14 @@ def test_pwm_concurrency_shared(iteration, pwm_dev):
 def test_pwm_concurrency_shared_error(iteration, pwm_dev):
     """Test for PWM concurrency bug"""
     with pytest.raises(PwmDeviceError):
-        threads = [PropagatingThread(target=pwm_open_set_config_close(pwm_dev)) for _ in range(100)]
-        for thread in threads:
-            thread.start()
-        for thread in threads:
-            thread.join()
+        threads_open_close = [PropagatingThread(target=pwm_open_close(pwm_dev)) for _ in range(10)]
+        threads_set_config = [PropagatingThread(target=pwm_set_config(pwm_dev)) for _ in range(10)]
+        for indx in range(len(threads_open_close)):
+            threads_open_close[indx].start()
+            threads_set_config[indx].start()
+        for indx in range(len(threads_open_close)):
+            threads_open_close[indx].join()
+            threads_set_config[indx].join()
 
 def pwm_open_set_config_indiv():
     """PWM init, setconfig and close"""
@@ -71,20 +75,36 @@ def pwm_open_set_config_indiv():
     pwm.init_pwm(PWMPins.PWM1)
     pwm.set_config(PWMPins.PWM1, frequency=1000, duty_cycle=0.5, polarity=Polarity.NORMAL)
 
-def pwm_open_set_config_close_indiv():
+def pwm_open_close_indiv():
     """PWM init, setconfig and close"""
     pwm = EdgePiPWM()
     pwm.init_pwm(PWMPins.PWM1)
-    pwm.set_config(PWMPins.PWM1, frequency=1000, duty_cycle=0.5, polarity=Polarity.NORMAL)
     pwm.close(PWMPins.PWM1)
+
+def pwm_set_config_indiv():
+    pwm = EdgePiPWM()
+    pwm.set_config(PWMPins.PWM1, frequency=1000, duty_cycle=0.5, polarity=Polarity.NORMAL)
+
 
 #pylint:disable=unused-argument
 @pytest.mark.parametrize("iteration", range(10))
-def test_pwm_concurrency_close_indiv(iteration):
+def test_pwm_concurrency_close_indiv_error(iteration):
     """Test for pwm concurrency bug"""
     with pytest.raises(PwmDeviceError):
-        threads = [PropagatingThread(target=pwm_open_set_config_close_indiv()) for _ in range(100)]
-        for thread in threads:
-            thread.start()
-        for thread in threads:
-            thread.join()
+        threads_open_close = [PropagatingThread(target=pwm_open_close_indiv()) for _ in range(10)]
+        threads_set_config = [PropagatingThread(target=pwm_set_config_indiv()) for _ in range(10)]
+        for indx in range(len(threads_open_close)):
+            threads_open_close[indx].start()
+            threads_set_config[indx].start()
+        for indx in range(len(threads_open_close)):
+            threads_open_close[indx].join()
+            threads_set_config[indx].join()
+
+@pytest.mark.parametrize("iteration", range(10))
+def test_pwm_concurrency_close_indiv(iteration, pwm_dev):
+    """Test for PWM concurrency bug"""
+    threads = [PropagatingThread(target=pwm_open_set_config_indiv()) for _ in range(10)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()

--- a/src/test_edgepi/unit_tests/test_pwm/test_edgepi_pwm.py
+++ b/src/test_edgepi/unit_tests/test_pwm/test_edgepi_pwm.py
@@ -102,8 +102,8 @@ def test_pwm_close(mocker, pwm_num, error, pwm_dev):
         assert pwm_dev._EdgePiPWM__pwm_devs[pwm_num] is None
 
 @pytest.mark.parametrize("pwm_num, error",
-                         [(PWMPins.PWM1, pytest.raises(OSError)),
-                          (PWMPins.PWM2, pytest.raises(OSError)),
+                         [(PWMPins.PWM1, pytest.raises(PwmDeviceError)),
+                          (PWMPins.PWM2, pytest.raises(PwmDeviceError)),
                           ])
 def test_pwm_close_with_exception(mocker, pwm_num, error, pwm_dev):
     mock_pwmdevice= mocker.patch("edgepi.peripherals.pwm.PwmDevice")

--- a/src/test_edgepi/unit_tests/test_pwm/test_edgepi_pwm.py
+++ b/src/test_edgepi/unit_tests/test_pwm/test_edgepi_pwm.py
@@ -114,20 +114,23 @@ def test_pwm_close_with_exception(mocker, pwm_num, error, pwm_dev):
         mock_pwmdevice.close_pwm.assert_called_once()
         assert pwm_dev._EdgePiPWM__pwm_devs[pwm_num] is None
 
-@pytest.mark.parametrize("pwm_num ,expected, error",
-                         [(PWMPins.PWM1, 1000.0, does_not_raise()),
-                          (PWMPins.PWM1, 5000.0, does_not_raise()),
-                          (PWMPins.PWM1, 10000.0, does_not_raise()),
-                          (PWMPins.PWM2, 1000.0, does_not_raise()),
-                          (PWMPins.PWM2, 5000.0, does_not_raise()),
-                          (PWMPins.PWM2, 10000.0, does_not_raise()),
-                          (None, 1000.0, pytest.raises(ValueError)),
-                          (None, 5000.0, pytest.raises(ValueError)),
-                          (None, 10000.0, pytest.raises(ValueError)),
+@pytest.mark.parametrize("pwm_num ,expected, error, dev_open",
+                         [(PWMPins.PWM1, 1000.0, does_not_raise(), True),
+                          (PWMPins.PWM1, 5000.0, does_not_raise(), True),
+                          (PWMPins.PWM1, 10000.0, does_not_raise(), True),
+                          (PWMPins.PWM2, 1000.0, does_not_raise(), True),
+                          (PWMPins.PWM2, 5000.0, does_not_raise(), True),
+                          (PWMPins.PWM2, 10000.0, does_not_raise(), True),
+                          (None, 1000.0, pytest.raises(ValueError), True),
+                          (None, 5000.0, pytest.raises(ValueError), True),
+                          (None, 10000.0, pytest.raises(ValueError), True),
+                        # Raise PWM Device Error
+                          (PWMPins.PWM2, 10000.0, pytest.raises(PwmDeviceError), False),
+                          (PWMPins.PWM1, 10000.0, pytest.raises(PwmDeviceError), False),
                           ])
-def test_get_frequency_pwm(mocker, pwm_num,expected, error, pwm_dev):
+def test_get_frequency_pwm(mocker, pwm_num,expected, error, dev_open, pwm_dev):
     mock_pwmdevice= mocker.patch("edgepi.peripherals.pwm.PwmDevice")
-    pwm_dev._EdgePiPWM__pwm_devs[pwm_num] = mock_pwmdevice
+    pwm_dev._EdgePiPWM__pwm_devs[pwm_num] = mock_pwmdevice if dev_open else None
     mocker.patch("edgepi.peripherals.pwm.PwmDevice.get_frequency_pwm", return_value = expected)
     with error:
         freq = pwm_dev.get_frequency(pwm_num)
@@ -154,32 +157,35 @@ def test_set_frequency_pwm(mocker, pwm_num, freq, error, pwm_dev):
         pwm_dev._EdgePiPWM__pwm_devs[pwm_num].set_frequency_pwm.assert_called_once_with(freq)
         assert result == freq
 
-@pytest.mark.parametrize("pwm_num ,expected, error",
-                         [(PWMPins.PWM1, 0.50, does_not_raise()),
-                          (PWMPins.PWM1, 0.40, does_not_raise()),
-                          (PWMPins.PWM1, 0.30, does_not_raise()),
-                          (PWMPins.PWM1, 0.20, does_not_raise()),
-                          (PWMPins.PWM1, 0.10, does_not_raise()),
-                          (PWMPins.PWM1, 0.60, does_not_raise()),
-                          (PWMPins.PWM1, 0.70, does_not_raise()),
-                          (PWMPins.PWM1, 0.80, does_not_raise()),
-                          (PWMPins.PWM1, 0.90, does_not_raise()),
-                          (PWMPins.PWM1, 1.00, does_not_raise()),
-                          (PWMPins.PWM2, 0.50, does_not_raise()),
-                          (PWMPins.PWM2, 0.40, does_not_raise()),
-                          (PWMPins.PWM2, 0.30, does_not_raise()),
-                          (PWMPins.PWM2, 0.20, does_not_raise()),
-                          (PWMPins.PWM2, 0.10, does_not_raise()),
-                          (PWMPins.PWM2, 0.60, does_not_raise()),
-                          (PWMPins.PWM2, 0.70, does_not_raise()),
-                          (PWMPins.PWM2, 0.80, does_not_raise()),
-                          (PWMPins.PWM2, 0.90, does_not_raise()),
-                          (PWMPins.PWM2, 1.00, does_not_raise()),
-                          (None, 0.50, pytest.raises(ValueError))
+@pytest.mark.parametrize("pwm_num ,expected, error, dev_open",
+                         [(PWMPins.PWM1, 0.50, does_not_raise(), True),
+                          (PWMPins.PWM1, 0.40, does_not_raise(), True),
+                          (PWMPins.PWM1, 0.30, does_not_raise(), True),
+                          (PWMPins.PWM1, 0.20, does_not_raise(), True),
+                          (PWMPins.PWM1, 0.10, does_not_raise(), True),
+                          (PWMPins.PWM1, 0.60, does_not_raise(), True),
+                          (PWMPins.PWM1, 0.70, does_not_raise(), True),
+                          (PWMPins.PWM1, 0.80, does_not_raise(), True),
+                          (PWMPins.PWM1, 0.90, does_not_raise(), True),
+                          (PWMPins.PWM1, 1.00, does_not_raise(), True),
+                          (PWMPins.PWM2, 0.50, does_not_raise(), True),
+                          (PWMPins.PWM2, 0.40, does_not_raise(), True),
+                          (PWMPins.PWM2, 0.30, does_not_raise(), True),
+                          (PWMPins.PWM2, 0.20, does_not_raise(), True),
+                          (PWMPins.PWM2, 0.10, does_not_raise(), True),
+                          (PWMPins.PWM2, 0.60, does_not_raise(), True),
+                          (PWMPins.PWM2, 0.70, does_not_raise(), True),
+                          (PWMPins.PWM2, 0.80, does_not_raise(), True),
+                          (PWMPins.PWM2, 0.90, does_not_raise(), True),
+                          (PWMPins.PWM2, 1.00, does_not_raise(), True),
+                          (None, 0.50, pytest.raises(ValueError), True),
+                          # Raise PWM Device Error
+                          (PWMPins.PWM2, 1.00, pytest.raises(PwmDeviceError), False),
+                          (PWMPins.PWM1, 1.00, pytest.raises(PwmDeviceError), False),
                           ])
-def test_get_duty_cycle_pwm(mocker, pwm_num ,expected, error, pwm_dev):
+def test_get_duty_cycle_pwm(mocker, pwm_num ,expected, error, dev_open, pwm_dev):
     mock_pwmdevice= mocker.patch("edgepi.peripherals.pwm.PwmDevice")
-    pwm_dev._EdgePiPWM__pwm_devs[pwm_num] = mock_pwmdevice
+    pwm_dev._EdgePiPWM__pwm_devs[pwm_num] = mock_pwmdevice if dev_open else None
     mocker.patch("edgepi.peripherals.pwm.PwmDevice.get_duty_cycle_pwm", return_value = expected)
     with error:
         duty_cycle = pwm_dev.get_duty_cycle(pwm_num)
@@ -220,16 +226,19 @@ def test_set_duty_cycle_pwm(mocker, pwm_num, duty_cycle, error, pwm_dev):
         pwm_dev._EdgePiPWM__pwm_devs[pwm_num].set_duty_cycle_pwm.assert_called_once_with(duty_cycle)
         assert result == duty_cycle
 
-@pytest.mark.parametrize("pwm_num, expected, error",
-                         [(PWMPins.PWM1, Polarity.NORMAL,does_not_raise()),
-                          (PWMPins.PWM1, Polarity.INVERSED,does_not_raise()),
-                          (PWMPins.PWM2, Polarity.NORMAL,does_not_raise()),
-                          (PWMPins.PWM2, Polarity.INVERSED,does_not_raise()),
-                          (None, Polarity.INVERSED,pytest.raises(ValueError)),
+@pytest.mark.parametrize("pwm_num, expected, error, dev_open",
+                         [(PWMPins.PWM1, Polarity.NORMAL,does_not_raise(), True),
+                          (PWMPins.PWM1, Polarity.INVERSED,does_not_raise(), True),
+                          (PWMPins.PWM2, Polarity.NORMAL,does_not_raise(), True),
+                          (PWMPins.PWM2, Polarity.INVERSED,does_not_raise(), True),
+                          (None, Polarity.INVERSED,pytest.raises(ValueError), True),
+                            # Raise PWM Device Error
+                          (PWMPins.PWM2, Polarity.INVERSED, pytest.raises(PwmDeviceError), False),
+                          (PWMPins.PWM1, Polarity.INVERSED, pytest.raises(PwmDeviceError), False),
                           ])
-def test_get_polarity_pwm(mocker, pwm_num, expected, error, pwm_dev):
+def test_get_polarity_pwm(mocker, pwm_num, expected, error, dev_open, pwm_dev):
     mock_pwmdevice= mocker.patch("edgepi.peripherals.pwm.PwmDevice")
-    pwm_dev._EdgePiPWM__pwm_devs[pwm_num] = mock_pwmdevice
+    pwm_dev._EdgePiPWM__pwm_devs[pwm_num] = mock_pwmdevice if dev_open else None
     mocker.patch("edgepi.peripherals.pwm.PwmDevice.get_polarity_pwm", return_value = expected)
     with error:
         polarity = pwm_dev.get_polarity(pwm_num)
@@ -253,14 +262,17 @@ def test__set_polarity_pwm(mocker, pwm_num, expected, error, pwm_dev):
         pwm_dev._EdgePiPWM__pwm_devs[pwm_num].set_polarity_pwm.assert_called_once_with(expected)
         assert result == expected
 
-@pytest.mark.parametrize("pwm_num, expected, error",
-                         [(PWMPins.PWM1, True, does_not_raise()),
-                          (PWMPins.PWM2, False, does_not_raise()),
-                          (None, False, pytest.raises(ValueError)),
+@pytest.mark.parametrize("pwm_num, expected, error, dev_open",
+                         [(PWMPins.PWM1, True, does_not_raise(), True),
+                          (PWMPins.PWM2, False, does_not_raise(), True),
+                          (None, False, pytest.raises(ValueError), True),
+                            # Raise PWM Device Error
+                          (PWMPins.PWM2, False, pytest.raises(PwmDeviceError), False),
+                          (PWMPins.PWM1, False, pytest.raises(PwmDeviceError), False),
                           ])
-def test_get_enabled(mocker, pwm_num, expected, error, pwm_dev):
+def test_get_enabled(mocker, pwm_num, expected, error, dev_open, pwm_dev):
     mock_pwmdevice= mocker.patch("edgepi.peripherals.pwm.PwmDevice")
-    pwm_dev._EdgePiPWM__pwm_devs[pwm_num] = mock_pwmdevice
+    pwm_dev._EdgePiPWM__pwm_devs[pwm_num] = mock_pwmdevice if dev_open else None
     mocker.patch("edgepi.peripherals.pwm.PwmDevice.get_enabled_pwm", return_value = expected)
     with error:
         enabled = pwm_dev.get_enabled(pwm_num)
@@ -300,6 +312,29 @@ def test_init_pwm_first_time(mocker, pwm_num,error):
             assert pwm_dev._EdgePiPWM__pwm_devs[PWMPins.PWM1] is None
         mock_open.assert_called_once()
 
+
+@pytest.mark.parametrize("pwm_num, error, set_fre_except, set_dt_except, set_pl_except",
+                        [
+                          (PWMPins.PWM1, pytest.raises(PwmDeviceError), True, False, False),
+                          (PWMPins.PWM2, pytest.raises(PwmDeviceError), False, True, False),
+                          (PWMPins.PWM2, pytest.raises(PwmDeviceError), False, False, True),
+                        ])
+def test_set_config_close_exceptions(mocker,
+                                     pwm_num,
+                                     error,
+                                     set_fre_except,
+                                     set_dt_except,
+                                     set_pl_except):
+    mocker.patch("edgepi.pwm.edgepi_pwm.EdgePiGPIO")
+    mocker.patch("edgepi.pwm.edgepi_pwm.EdgePiPWM._EdgePiPWM__set_frequency",
+                                 side_effect=Exception if set_fre_except else None)
+    mocker.patch("edgepi.pwm.edgepi_pwm.EdgePiPWM._EdgePiPWM__set_duty_cycle",
+                                 side_effect=Exception if set_dt_except else None)
+    mocker.patch("edgepi.pwm.edgepi_pwm.EdgePiPWM._EdgePiPWM__set_polarity",
+                                 side_effect=Exception if set_pl_except else None)
+    pwm_dev = EdgePiPWM()
+    with error:
+        pwm_dev.set_config(pwm_num)
 
 @pytest.mark.parametrize("pwm_num, error",
                         [(None, pytest.raises(ValueError)),


### PR DESCRIPTION
Closes #401 

- added try except finally for set_config() method to bubble up the error
- Init_pwm throws OS/IO/PWM error during integration test where it opens and closes concurrently. This is not a normal use case and should bubble up the error. So implemented a locking and raise PWMDeviceError with Exception information