### PR TITLE
Forces `bitstring` dependency to  < 4.2.0

### DIFF
--- a/.github/workflows/python-integration-test.yml
+++ b/.github/workflows/python-integration-test.yml
@@ -20,6 +20,9 @@ jobs:
         python-version: ["3.9"]
 
     steps:
+      - name: Check pi user groups
+        run: |
+          groups pi | grep -q -P '^(?=.*spi)(?=.*i2c)(?=.*dialout)(?=.*gpio)'
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install Dependencies

--- a/.github/workflows/python-integration-test.yml
+++ b/.github/workflows/python-integration-test.yml
@@ -24,10 +24,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Install Dependencies
         run: |
-          python -m pip install --upgrade pip
           python -m venv venv_test
           source venv_test/bin/activate
-          python -m pip install pytest
+          pip install --upgrade pip
+          pip install pytest
           if [ -f requirements_test.txt ]; then pip install -r requirements_test.txt; fi
       - name: Test with pytest
         run: |

--- a/.github/workflows/python-integration-test.yml
+++ b/.github/workflows/python-integration-test.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Test with pytest
         run: |
           source venv_test/bin/activate
-          python -m pytest ./src/test_edgepi/integration_tests
+          pytest ./src/test_edgepi/integration_tests
       # python -m pytest ../tests/integration_tests --cov --cov-report=xml
       # - name: Code Coverage Summary Report
       #   uses: irongut/CodeCoverageSummary@v1.2.0

--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,5 @@ setuptools.setup(
     packages=setuptools.find_packages(where="src", exclude=["test_edgepi"]),
     package_dir={"": "src"},
     python_requires=">=3.6",
-    install_requires=["python-periphery >= 2.3.0", "bitstring >= 3.1.9", "protobuf>=3.20"],
+    install_requires=["python-periphery >= 2.3.0", "bitstring >= 3.1.9, < 4.0.0", "protobuf>=3.20"],
 )

--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,5 @@ setuptools.setup(
     packages=setuptools.find_packages(where="src", exclude=["test_edgepi"]),
     package_dir={"": "src"},
     python_requires=">=3.6",
-    install_requires=["python-periphery >= 2.3.0", "bitstring >= 3.1.9, < 4.0.0", "protobuf>=3.20"],
+    install_requires=["python-periphery >= 2.3.0", "bitstring >= 3.1.9, < 4.2.0", "protobuf>=3.20"],
 )


### PR DESCRIPTION
closes #409 
also fixes a minor workflow issue.
