### PR TITLE
Fix hw tests

### DIFF
--- a/src/test_edgepi/integration_tests/test_dac/test_dac.py
+++ b/src/test_edgepi/integration_tests/test_dac/test_dac.py
@@ -71,6 +71,8 @@ def test_dac_write_and_read_voltages(analog_out, voltage, raises, dac):
     with raises:
         # expected_voltage = (voltage)*dac.dac_ops.dict_calib_param[analog_out.value].gain -\
         #  dac.dac_ops.dict_calib_param[analog_out.value].offset
+        # explicitly disable dac gain for this test
+        dac.set_dac_gain(False)
         dac.write_voltage(analog_out, voltage)
         code, voltage_val, gain_state = dac.get_state(analog_out, True, True, True)
         dac_gain = 2 if gain_state else 1

--- a/src/test_edgepi/integration_tests/test_eeprom/test_eeprom.py
+++ b/src/test_edgepi/integration_tests/test_eeprom/test_eeprom.py
@@ -33,6 +33,8 @@ def fixture_test_eeprom():
                         ])
 # pylint: disable=protected-access
 def test__page_write_register(data, address, eeprom):
+    # reset user space to make sure init vals are set to 255
+    eeprom.reset_user_space()
     addrx = EdgePiMemoryInfo.USER_SPACE_START_BYTE.value + address
     with eeprom.i2c_open():
         initial_data = eeprom._EdgePiEEPROM__sequential_read(addrx,len(data))

--- a/tests/hardware_tests/test_voltage_rw.py
+++ b/tests/hardware_tests/test_voltage_rw.py
@@ -134,7 +134,7 @@ def _measure_voltage_differential(
     for _ in range(READS_PER_WRITE):
         read_voltage = adc.read_voltage(adc_num)
         _logger.info(f"diff_read_voltage = {read_voltage}")
-        _assert_approx(write_volt/2, read_voltage, RW_ERROR)
+        _assert_approx(write_volt, read_voltage, RW_ERROR)
 
 
 _diff_ch_map = {


### PR DESCRIPTION
closes #412 #413 #415 #416

## intg tests
### `src/test_edgepi/integration_tests/test_dac/test_dac.py`
```
src/test_edgepi/integration_tests/test_dac/test_dac.py ...........................                                                                                                                               [100%]

================================================================================================= 27 passed in 57.52s ==================================================================================================
```
### `src/test_edgepi/integration_tests/test_eeprom/test_eeprom.py`
```
src/test_edgepi/integration_tests/test_eeprom/test_eeprom.py ......                                                                                                                                              [100%]

======================================================================================================== PASSES ========================================================================================================
__________________________________________________________________________________________ test__page_write_register[data0-0] __________________________________________________________________________________________
-------------------------------------------------------------------------------------------------- Captured log setup --------------------------------------------------------------------------------------------------
18:01:01 INFO [edgepi_eeprom.py:40] Initializing EEPROM Access
-------------------------------------------------------------------------------------------------- Captured log call ---------------------------------------------------------------------------------------------------
18:01:01 INFO [edgepi_eeprom.py:380] EEPROM Reset: User Space Memory Reset
18:01:06 INFO [test_eeprom.py:45] data to write = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63]
18:01:06 INFO [test_eeprom.py:46] initial data  = [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]
18:01:06 INFO [test_eeprom.py:47] new data      = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63]
_________________________________________________________________________________________ test__page_write_register[data1-64] __________________________________________________________________________________________
-------------------------------------------------------------------------------------------------- Captured log setup --------------------------------------------------------------------------------------------------
18:01:06 INFO [edgepi_eeprom.py:40] Initializing EEPROM Access
-------------------------------------------------------------------------------------------------- Captured log call ---------------------------------------------------------------------------------------------------
18:01:06 INFO [edgepi_eeprom.py:380] EEPROM Reset: User Space Memory Reset
18:01:11 INFO [test_eeprom.py:45] data to write = [64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127]
18:01:11 INFO [test_eeprom.py:46] initial data  = [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]
18:01:11 INFO [test_eeprom.py:47] new data      = [64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127]
________________________________________________________________________________________________ test_write_edgepi_data ________________________________________________________________________________________________
-------------------------------------------------------------------------------------------------- Captured log setup --------------------------------------------------------------------------------------------------
18:01:11 INFO [edgepi_eeprom.py:40] Initializing EEPROM Access
________________________________________________________________________________________ test_reset_edgepi_memory[None-error0] _________________________________________________________________________________________
-------------------------------------------------------------------------------------------------- Captured log setup --------------------------------------------------------------------------------------------------
18:02:16 INFO [edgepi_eeprom.py:40] Initializing EEPROM Access
____________________________________________________________________________________ test_reset_edgepi_memory[This is Dummy-error1] ____________________________________________________________________________________
-------------------------------------------------------------------------------------------------- Captured log setup --------------------------------------------------------------------------------------------------
18:02:19 INFO [edgepi_eeprom.py:40] Initializing EEPROM Access
__________________________________________________________________________ test_reset_edgepi_memory[6b68b8e2dd2a6bec300ef91572270723-error2] ___________________________________________________________________________
-------------------------------------------------------------------------------------------------- Captured log setup --------------------------------------------------------------------------------------------------
18:02:21 INFO [edgepi_eeprom.py:40] Initializing EEPROM Access
============================================================================================= 6 passed in 84.47s (0:01:24) =============================================================================================

```
## hw tests
### `tests/hardware_tests/test_eeprom_userspace.py`
``` 
tests/hardware_tests/test_eeprom_userspace.py ..                                                                                                                                                                 [100%]

================================================================================================== 2 passed in 6.33s ===================================================================================================
```
### `tests/hardware_tests/test_voltage_rw.py`
```
======================================================================================================== PASSES ========================================================================================================
_____________________________________________________________________________________________ test_voltage_rw_adc_1[0-1.0] _____________________________________________________________________________________________
-------------------------------------------------------------------------------------------------- Captured log setup --------------------------------------------------------------------------------------------------
17:39:59 INFO [edgepi_eeprom.py:40] Initializing EEPROM Access
17:40:01 INFO [adc_commands.py:17] Initializing ADC Methods
17:40:01 INFO [edgepi_gpio.py:26] GPIO initializing
17:40:01 INFO [edgepi_dac.py:57] Initializing DAC Bus
17:40:01 INFO [edgepi_eeprom.py:40] Initializing EEPROM Access
17:40:03 INFO [dac_commands.py:21] Initializing DAC Methods
17:40:03 INFO [edgepi_gpio.py:26] GPIO initializing
-------------------------------------------------------------------------------------------------- Captured log call ---------------------------------------------------------------------------------------------------
17:40:03 INFO [test_voltage_rw.py:81] 
channel_number=0, write_voltage=1.0 V, read_voltage=1.0125543068481315 V
assert 1.0125543068481315 == 1.0 ± 0.1
_____________________________________________________________________________________________ test_voltage_rw_adc_1[0-2.0] _____________________________________________________________________________________________
-------------------------------------------------------------------------------------------------- Captured log call ---------------------------------------------------------------------------------------------------
17:40:03 INFO [test_voltage_rw.py:81] 
channel_number=0, write_voltage=2.0 V, read_voltage=2.038968940111967 V
assert 2.038968940111967 == 2.0 ± 0.1
_____________________________________________________________________________________________ test_voltage_rw_adc_1[0-3.0] _____________________________________________________________________________________________
-------------------------------------------------------------------------------------------------- Captured log call ---------------------------------------------------------------------------------------------------
17:40:04 INFO [test_voltage_rw.py:81] 
channel_number=0, write_voltage=3.0 V, read_voltage=3.0660437251406654 V
assert 3.0660437251406654 == 3.0 ± 0.1
_____________________________________________________________________________________________ test_voltage_rw_adc_1[0-4.0] _____________________________________________________________________________________________
-------------------------------------------------------------------------------------------------- Captured log call ---------------------------------------------------------------------------------------------------
17:40:04 INFO [test_voltage_rw.py:81] 
channel_number=0, write_voltage=4.0 V, read_voltage=4.09294439852751 V
assert 4.09294439852751 == 4.0 ± 0.1
_____________________________________________________________________________________________ test_voltage_rw_adc_1[1-1.0] _____________________________________________________________________________________________
-------------------------------------------------------------------------------------------------- Captured log call ---------------------------------------------------------------------------------------------------
17:40:04 INFO [test_voltage_rw.py:81] 
channel_number=1, write_voltage=1.0 V, read_voltage=1.0103052767588083 V
assert 1.0103052767588083 == 1.0 ± 0.1
_____________________________________________________________________________________________ test_voltage_rw_adc_1[1-2.0] _____________________________________________________________________________________________
-------------------------------------------------------------------------------------------------- Captured log call ---------------------------------------------------------------------------------------------------
17:40:04 INFO [test_voltage_rw.py:81] 
channel_number=1, write_voltage=2.0 V, read_voltage=2.036839545739886 V
assert 2.036839545739886 == 2.0 ± 0.1
_____________________________________________________________________________________________ test_voltage_rw_adc_1[1-3.0] _____________________________________________________________________________________________
-------------------------------------------------------------------------------------------------- Captured log call ---------------------------------------------------------------------------------------------------
17:40:04 INFO [test_voltage_rw.py:81] 
channel_number=1, write_voltage=3.0 V, read_voltage=3.063910441638301 V
assert 3.063910441638301 == 3.0 ± 0.1
_____________________________________________________________________________________________ test_voltage_rw_adc_1[1-4.0] _____________________________________________________________________________________________
-------------------------------------------------------------------------------------------------- Captured log call ---------------------------------------------------------------------------------------------------
17:40:05 INFO [test_voltage_rw.py:81] 
channel_number=1, write_voltage=4.0 V, read_voltage=4.090955310712525 V
assert 4.090955310712525 == 4.0 ± 0.1
_____________________________________________________________________________________________ test_voltage_rw_adc_2[0-1.0] _____________________________________________________________________________________________
-------------------------------------------------------------------------------------------------- Captured log setup --------------------------------------------------------------------------------------------------
17:40:05 INFO [edgepi_eeprom.py:40] Initializing EEPROM Access
17:40:07 INFO [adc_commands.py:17] Initializing ADC Methods
17:40:07 INFO [edgepi_gpio.py:26] GPIO initializing
-------------------------------------------------------------------------------------------------- Captured log call ---------------------------------------------------------------------------------------------------
17:40:07 INFO [test_voltage_rw.py:81] 
channel_number=0, write_voltage=1.0 V, read_voltage=1.012476664745736 V
assert 1.012476664745736 == 1.0 ± 0.1
_____________________________________________________________________________________________ test_voltage_rw_adc_2[0-2.0] _____________________________________________________________________________________________
-------------------------------------------------------------------------------------------------- Captured log call ---------------------------------------------------------------------------------------------------
17:40:07 INFO [test_voltage_rw.py:81] 
channel_number=0, write_voltage=2.0 V, read_voltage=2.0390444802855683 V
assert 2.0390444802855683 == 2.0 ± 0.1
_____________________________________________________________________________________________ test_voltage_rw_adc_2[0-3.0] _____________________________________________________________________________________________
-------------------------------------------------------------------------------------------------- Captured log call ---------------------------------------------------------------------------------------------------
17:40:08 INFO [test_voltage_rw.py:81] 
channel_number=0, write_voltage=3.0 V, read_voltage=3.0645058944612322 V
assert 3.0645058944612322 == 3.0 ± 0.1
_____________________________________________________________________________________________ test_voltage_rw_adc_2[0-4.0] _____________________________________________________________________________________________
-------------------------------------------------------------------------------------------------- Captured log call ---------------------------------------------------------------------------------------------------
17:40:08 INFO [test_voltage_rw.py:81] 
channel_number=0, write_voltage=4.0 V, read_voltage=4.092634757439455 V
assert 4.092634757439455 == 4.0 ± 0.1
_____________________________________________________________________________________________ test_voltage_rw_adc_2[1-1.0] _____________________________________________________________________________________________
-------------------------------------------------------------------------------------------------- Captured log call ---------------------------------------------------------------------------------------------------
17:40:08 INFO [test_voltage_rw.py:81] 
channel_number=1, write_voltage=1.0 V, read_voltage=1.0099689175705155 V
assert 1.0099689175705155 == 1.0 ± 0.1
_____________________________________________________________________________________________ test_voltage_rw_adc_2[1-2.0] _____________________________________________________________________________________________
-------------------------------------------------------------------------------------------------- Captured log call ---------------------------------------------------------------------------------------------------
17:40:08 INFO [test_voltage_rw.py:81] 
channel_number=1, write_voltage=2.0 V, read_voltage=2.0370000117049667 V
assert 2.0370000117049667 == 2.0 ± 0.1
_____________________________________________________________________________________________ test_voltage_rw_adc_2[1-3.0] _____________________________________________________________________________________________
-------------------------------------------------------------------------------------------------- Captured log call ---------------------------------------------------------------------------------------------------
17:40:09 INFO [test_voltage_rw.py:81] 
channel_number=1, write_voltage=3.0 V, read_voltage=3.0623031630066926 V
assert 3.0623031630066926 == 3.0 ± 0.1
_____________________________________________________________________________________________ test_voltage_rw_adc_2[1-4.0] _____________________________________________________________________________________________
-------------------------------------------------------------------------------------------------- Captured log call ---------------------------------------------------------------------------------------------------
17:40:09 INFO [test_voltage_rw.py:81] 
channel_number=1, write_voltage=4.0 V, read_voltage=4.090691001596814 V
assert 4.090691001596814 == 4.0 ± 0.1
___________________________________________________________________________________ test_differential_rw_adc_1[DiffMode.DIFF_2-1.0] ____________________________________________________________________________________
-------------------------------------------------------------------------------------------------- Captured log call ---------------------------------------------------------------------------------------------------
17:40:09 INFO [test_voltage_rw.py:157] voltage read/write diff pair: mux_p = ADCChannel.AIN2, mux_n = ADCChannel.AIN3
17:40:09 INFO [test_voltage_rw.py:160] mux_p_write_voltage = 1.0
17:40:09 INFO [test_voltage_rw.py:136] diff_read_voltage = 0.9829538102977479
___________________________________________________________________________________ test_differential_rw_adc_1[DiffMode.DIFF_2-2.0] ____________________________________________________________________________________
-------------------------------------------------------------------------------------------------- Captured log call ---------------------------------------------------------------------------------------------------
17:40:09 INFO [test_voltage_rw.py:157] voltage read/write diff pair: mux_p = ADCChannel.AIN2, mux_n = ADCChannel.AIN3
17:40:09 INFO [test_voltage_rw.py:160] mux_p_write_voltage = 2.0
17:40:09 INFO [test_voltage_rw.py:136] diff_read_voltage = 2.000142448627948
___________________________________________________________________________________ test_differential_rw_adc_1[DiffMode.DIFF_2-3.0] ____________________________________________________________________________________
-------------------------------------------------------------------------------------------------- Captured log call ---------------------------------------------------------------------------------------------------
17:40:09 INFO [test_voltage_rw.py:157] voltage read/write diff pair: mux_p = ADCChannel.AIN2, mux_n = ADCChannel.AIN3
17:40:09 INFO [test_voltage_rw.py:160] mux_p_write_voltage = 3.0
17:40:10 INFO [test_voltage_rw.py:136] diff_read_voltage = 3.0222308291015
___________________________________________________________________________________ test_differential_rw_adc_1[DiffMode.DIFF_2-4.0] ____________________________________________________________________________________
-------------------------------------------------------------------------------------------------- Captured log call ---------------------------------------------------------------------------------------------------
17:40:10 INFO [test_voltage_rw.py:157] voltage read/write diff pair: mux_p = ADCChannel.AIN2, mux_n = ADCChannel.AIN3
17:40:10 INFO [test_voltage_rw.py:160] mux_p_write_voltage = 4.0
17:40:10 INFO [test_voltage_rw.py:136] diff_read_voltage = 4.042702399202173
___________________________________________________________________________________ test_differential_rw_adc_2[DiffMode.DIFF_2-1.0] ____________________________________________________________________________________
-------------------------------------------------------------------------------------------------- Captured log call ---------------------------------------------------------------------------------------------------
17:40:10 INFO [test_voltage_rw.py:173] voltage read/write diff pair: mux_p = ADCChannel.AIN2, mux_n = ADCChannel.AIN3
17:40:10 INFO [test_voltage_rw.py:176] mux_p_write_voltage = 1.0
17:40:10 INFO [test_voltage_rw.py:136] diff_read_voltage = 1.0064813793302776
___________________________________________________________________________________ test_differential_rw_adc_2[DiffMode.DIFF_2-2.0] ____________________________________________________________________________________
-------------------------------------------------------------------------------------------------- Captured log call ---------------------------------------------------------------------------------------------------
17:40:10 INFO [test_voltage_rw.py:173] voltage read/write diff pair: mux_p = ADCChannel.AIN2, mux_n = ADCChannel.AIN3
17:40:10 INFO [test_voltage_rw.py:176] mux_p_write_voltage = 2.0
17:40:10 INFO [test_voltage_rw.py:136] diff_read_voltage = 2.0322693905276146
___________________________________________________________________________________ test_differential_rw_adc_2[DiffMode.DIFF_2-3.0] ____________________________________________________________________________________
-------------------------------------------------------------------------------------------------- Captured log call ---------------------------------------------------------------------------------------------------
17:40:11 INFO [test_voltage_rw.py:173] voltage read/write diff pair: mux_p = ADCChannel.AIN2, mux_n = ADCChannel.AIN3
17:40:11 INFO [test_voltage_rw.py:176] mux_p_write_voltage = 3.0
17:40:11 INFO [test_voltage_rw.py:136] diff_read_voltage = 3.058523557826369
___________________________________________________________________________________ test_differential_rw_adc_2[DiffMode.DIFF_2-4.0] ____________________________________________________________________________________
-------------------------------------------------------------------------------------------------- Captured log call ---------------------------------------------------------------------------------------------------
17:40:11 INFO [test_voltage_rw.py:173] voltage read/write diff pair: mux_p = ADCChannel.AIN2, mux_n = ADCChannel.AIN3
17:40:11 INFO [test_voltage_rw.py:176] mux_p_write_voltage = 4.0
17:40:11 INFO [test_voltage_rw.py:136] diff_read_voltage = 4.084638166045378
================================================================================================= 24 passed in 12.66s ==================================================================================================
```