### PR TITLE
Implement high frequency reads for ADC and Digital In 

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -5,7 +5,9 @@ disable=logging-fstring-interpolation,
         too-many-arguments,
         fixme,
         too-few-public-methods,
-        duplicate-code
+        duplicate-code,
+        no-else-return,
+        no-else-raise
 
 [LOGGING]
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -7,7 +7,8 @@ disable=logging-fstring-interpolation,
         too-few-public-methods,
         duplicate-code,
         no-else-return,
-        no-else-raise
+        no-else-raise,
+        logging-fstring-interpolation
 
 [LOGGING]
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Use [GitHub Issues Page](https://github.com/EdgePi-Cloud/edgepi-python-sdk/issue
 
 # Get involved
 Follow [@edgepi_cloud on Twitter](https://twitter.com/edgepi_cloud/).
-Read and subscribe to the [EdgePi blog](https://www.edgepi.com/blog).
+See the [EdgePi wiki](https://wiki.edgepi.com/) for more information on how to get started with your EdgePi.
 If you have a specific question, please check out our [discussion forums](https://www.edgepi.com/forums).
 
 # License

--- a/src/edgepi/adc/adc_commands.py
+++ b/src/edgepi/adc/adc_commands.py
@@ -30,6 +30,11 @@ class ADCCommands:
         command = [ADCComs.COM_WREG.value + address, len(values) - 1]
         return command + values
 
+    def unsafe_write_register_command(self, address, values):
+        """Trigger ADC register write - unsafe removes all checks"""
+        command = [ADCComs.COM_WREG.value + address, len(values) - 1]
+        return command + values
+
     def start_adc(self, adc_num: ADCNum):
         """Command to start ADC"""
         _logger.debug("Command to send is %s", ([adc_num.start_cmd]))

--- a/src/edgepi/adc/adc_constants.py
+++ b/src/edgepi/adc/adc_constants.py
@@ -8,9 +8,9 @@ from edgepi.reg_helper.reg_helper import BitMask, OpCode
 
 
 ADC_NUM_REGS = 27  # number of ADC1263 registers
-ADC_VOLTAGE_READ_LEN = 6  # number of bytes per voltage read
-ADC1_NUM_DATA_BYTES = 4 # Number of data bytes for ADC 1
-ADC2_NUM_DATA_BYTES = 3 # Number of data bytes for ADC 2
+ADC_VOLTAGE_READ_LEN = 6 # number of bytes per voltage read
+ADC1_NUM_DATA_BYTES  = 4 # Number of data bytes for ADC 1
+ADC2_NUM_DATA_BYTES  = 3 # Number of data bytes for ADC 2
 
 
 @unique

--- a/src/edgepi/adc/adc_constants.py
+++ b/src/edgepi/adc/adc_constants.py
@@ -9,8 +9,8 @@ from edgepi.reg_helper.reg_helper import BitMask, OpCode
 
 ADC_NUM_REGS = 27  # number of ADC1263 registers
 ADC_VOLTAGE_READ_LEN = 6 # number of bytes per voltage read
-ADC1_NUM_DATA_BYTES  = 4 # Number of data bytes for ADC 1
-ADC2_NUM_DATA_BYTES  = 3 # Number of data bytes for ADC 2
+ADC1_NUM_DATA_BYTES = 4 # Number of data bytes for ADC 1
+ADC2_NUM_DATA_BYTES = 3 # Number of data bytes for ADC 2
 
 
 @unique

--- a/src/edgepi/adc/adc_multiplexers.py
+++ b/src/edgepi/adc/adc_multiplexers.py
@@ -52,7 +52,8 @@ def generate_mux_opcodes(adc1_reg, adc1_mux, adc2_reg, adc2_mux):
         if mux_p is None or mux_n is None:
             return []
 
-        # NOTE: for this function, we know that mux_p_val can never be larger than 15, because mux_p and mux_n are ADCChannel
+        # NOTE: for this function, we know that mux_p_val can never be larger than 15, 
+        # because mux_p and mux_n are ADCChannel
         mux_p_val, mux_n_val, mask = _format_mux_values(mux_p, mux_n)
 
         adc_x_ch_bits = (mux_p_val << 4) + mux_n_val
@@ -78,8 +79,9 @@ def validate_channels_allowed(channels: list, rtd_enabled: bool):
         if rtd_enabled
         else AllowedChannels.RTD_OFF.value
     )
-    for ch in channels:
-        if ch not in allowed_channels:
+    for chan in channels:
+        if chan not in allowed_channels:
             raise ChannelNotAvailableError(
-                f"Channel 'AIN{ch.value}' is currently not available. Disable RTD in order to use."
+                f"Channel 'AIN{chan.value}' is currently not available. "
+                "Disable RTD in order to use."
             )

--- a/src/edgepi/adc/adc_multiplexers.py
+++ b/src/edgepi/adc/adc_multiplexers.py
@@ -76,15 +76,15 @@ def generate_mux_opcodes(mux_updates: dict):
 def DEV_generate_mux_opcodes(key1, value1, key2, value2):
     mux_opcodes = []
 
-    def do_opcode(addx, mux_p, mux_n):
+    def do_opcode(addx, mux_p: CH, mux_n: CH):
         # not updating mux's for this adc_num (no args passed)
         if mux_p is None or mux_n is None:
             return []
 
+        # NOTE: for this function, we know that mux_p_val can never be larger than 15, because mux_p and mux_n are ADCChannel
         mux_p_val, mux_n_val, mask = _format_mux_values(mux_p, mux_n)
 
-        adc_x_ch_bits = pack("uint:4, uint:4", mux_p_val, mux_n_val).uint
-
+        adc_x_ch_bits = (mux_p_val << 4) + mux_n_val
         return [OpCode(adc_x_ch_bits, addx.value, mask.value)]
 
     mux_opcodes += do_opcode(key1, value1[0], value1[1])

--- a/src/edgepi/adc/adc_multiplexers.py
+++ b/src/edgepi/adc/adc_multiplexers.py
@@ -46,7 +46,7 @@ def generate_mux_opcodes(mux_updates: dict):
     Returns:
         `list`: OpCodes for updated multiplexer mapping
     """
-    _logger.debug(f"generate_mux_opcodes: mux updates = {mux_updates}")
+    _logger.debug("generate_mux_opcodes: mux updates = {}".format(mux_updates))
 
     mux_opcodes = []
     # generate OpCodes for mux updates
@@ -62,8 +62,7 @@ def generate_mux_opcodes(mux_updates: dict):
 
         mux_opcodes.append(OpCode(adc_x_ch_bits, addx.value, mask.value))
 
-    _logger.debug(f"mux opcodes = {mux_opcodes}")
-
+    _logger.debug("mux opcodes = {}".format(mux_opcodes))
     return mux_opcodes
 
 def validate_channels_allowed(channels: list, rtd_enabled: bool):

--- a/src/edgepi/adc/adc_multiplexers.py
+++ b/src/edgepi/adc/adc_multiplexers.py
@@ -37,7 +37,7 @@ def generate_mux_opcodes(adc1_mux: (CH, CH), adc2_mux: (CH, CH)) -> list:
         `adc2_mux` (ADCChannel, ADCChannel): The new channel values for for updating
             multiplexer mapping for adc2. The first is mux_p, the second is mux_n.
 
-        Note: both of the above must be dictionaries formatted as (mux_p_val, mux_n_val)
+        Note: both of the above must be tuples must be formatted as (mux_p_val, mux_n_val)
 
     Returns:
         `list`: OpCodes for updated multiplexer mapping

--- a/src/edgepi/adc/adc_state.py
+++ b/src/edgepi/adc/adc_state.py
@@ -24,7 +24,7 @@ class ADCReadFields:
 
 class ADCState:
     """ADC state intended for reading by users"""
-# pylint: disable=too-many-instance-attributes
+    # pylint: disable=too-many-instance-attributes
     def __init__(self, reg_map: dict):
         self.__reg_map = reg_map
         self.adc_1: ADCReadFields = ADCReadFields(
@@ -44,6 +44,19 @@ class ADCState:
         self.checksum_mode: PropertyValue = self.__get_state(ADCProperties.CHECK_MODE)
         self.rtd_adc: ADCNum = self.__get_rtd_adc_num()
         self.rtd_mode: RTDModes = self.__get_rtd_mode()
+
+    def get_state(reg_map: dict, adc_property: ADCProperties) -> PropertyValue:
+        """
+        A static method that uses a provided register map to determine a single required adc_property
+        """
+        # value of this adc_property's register
+        reg_value = reg_map[adc_property.value.addx]
+        # get value of bits corresponding to this property by letting through only the bits
+        # that were "masked" when setting this property (clear all bits except the property bits)
+        adc_property_bits = (~adc_property.value.mask) & reg_value
+        # name of current value of this adc_property
+        adc_property_value = adc_property.value.values[adc_property_bits]
+        return adc_property_value
 
     def __query_state(self, adc_property: ADCProperties) -> PropertyValue:
         """

--- a/src/edgepi/adc/adc_state.py
+++ b/src/edgepi/adc/adc_state.py
@@ -45,6 +45,7 @@ class ADCState:
         self.rtd_adc: ADCNum = self.__get_rtd_adc_num()
         self.rtd_mode: RTDModes = self.__get_rtd_mode()
 
+    @staticmethod
     def get_state(reg_map: dict, adc_property: ADCProperties) -> PropertyValue:
         """
         A static method that uses the provided register map to determine a single adc_property, 

--- a/src/edgepi/adc/adc_state.py
+++ b/src/edgepi/adc/adc_state.py
@@ -63,13 +63,14 @@ class ADCState:
         adc_property_bits = (~adc_property.value.mask) & reg_value
         # name of current value of this adc_property
         adc_property_value = adc_property.value.values[adc_property_bits]
-        _logger.debug(
-            (
-                f"query_state: query_property='{adc_property}',"
-                " adc_property_bits={hex(adc_property_bits)},"
-                f" adc_property_value='{adc_property_value}'"
-            )
-        )
+        # this log statement is disabled because it affects performance a lot
+        #_logger.debug(
+        #    (
+        #        f"query_state: query_property='{adc_property}',"
+        #        " adc_property_bits={hex(adc_property_bits)},"
+        #        f" adc_property_value='{adc_property_value}'"
+        #    )
+        #)
         return adc_property_value
 
     def __get_state(self, adc_property: ADCProperties) -> PropertyValue:

--- a/src/edgepi/adc/adc_state.py
+++ b/src/edgepi/adc/adc_state.py
@@ -47,7 +47,8 @@ class ADCState:
 
     def get_state(reg_map: dict, adc_property: ADCProperties) -> PropertyValue:
         """
-        A static method that uses a provided register map to determine a single required adc_property
+        A static method that uses the provided register map to determine a single adc_property, 
+        rather than computing all of them
         """
         # value of this adc_property's register
         reg_value = reg_map[adc_property.value.addx]
@@ -76,14 +77,13 @@ class ADCState:
         adc_property_bits = (~adc_property.value.mask) & reg_value
         # name of current value of this adc_property
         adc_property_value = adc_property.value.values[adc_property_bits]
-        # this log statement is disabled because it affects performance a lot
-        #_logger.debug(
-        #    (
-        #        f"query_state: query_property='{adc_property}',"
-        #        " adc_property_bits={hex(adc_property_bits)},"
-        #        f" adc_property_value='{adc_property_value}'"
-        #    )
-        #)
+        _logger.debug(
+            (
+                "query_state: query_property='{}',".format(adc_property) +
+                " adc_property_bits={},".format(hex(adc_property_bits)) +
+                " adc_property_value='{}'".format(adc_property_value)
+            )
+        )
         return adc_property_value
 
     def __get_state(self, adc_property: ADCProperties) -> PropertyValue:

--- a/src/edgepi/adc/adc_state.py
+++ b/src/edgepi/adc/adc_state.py
@@ -79,10 +79,11 @@ class ADCState:
         # name of current value of this adc_property
         adc_property_value = adc_property.value.values[adc_property_bits]
         _logger.debug(
+
             (
-                "query_state: query_property='{}',".format(adc_property) +
-                " adc_property_bits={},".format(hex(adc_property_bits)) +
-                " adc_property_value='{}'".format(adc_property_value)
+                f"query_state: query_property='{adc_property}',"
+                f" adc_property_bits={hex(adc_property_bits)},"
+                f" adc_property_value='{adc_property_value}'"
             )
         )
         return adc_property_value

--- a/src/edgepi/adc/adc_status.py
+++ b/src/edgepi/adc/adc_status.py
@@ -2,9 +2,9 @@
 
 from dataclasses import dataclass
 from enum import Enum, unique
+from functools import lru_cache
 
-import bitstring
-
+from bitstring import pack
 
 @unique
 class ADCStatusBit(Enum):
@@ -87,7 +87,7 @@ _fault_msg_map = {
     ADCStatusBit.RESET: (ADCStatusMsg.RESET_FALSE, ADCStatusMsg.RESET_TRUE),
 }
 
-
+@lru_cache(maxsize=128)
 def get_adc_status(status_code: int) -> dict:
     """Generates a dictionary of ADC Status objects
 
@@ -99,7 +99,7 @@ def get_adc_status(status_code: int) -> dict:
     """
     status_dict = {}
 
-    status_byte = bitstring.pack("uint:8", status_code)
+    status_byte = pack("uint:8", status_code)
 
     # check each bit in status_byte
     for bit_num in ADCStatusBit:

--- a/src/edgepi/adc/adc_status.py
+++ b/src/edgepi/adc/adc_status.py
@@ -2,7 +2,6 @@
 
 from dataclasses import dataclass
 from enum import Enum, unique
-from functools import lru_cache
 
 from bitstring import pack
 
@@ -87,7 +86,6 @@ _fault_msg_map = {
     ADCStatusBit.RESET: (ADCStatusMsg.RESET_FALSE, ADCStatusMsg.RESET_TRUE),
 }
 
-@lru_cache(maxsize=128)
 def get_adc_status(status_code: int) -> dict:
     """Generates a dictionary of ADC Status objects
 

--- a/src/edgepi/adc/adc_voltage.py
+++ b/src/edgepi/adc/adc_voltage.py
@@ -6,7 +6,7 @@ import logging
 from bitstring import BitArray
 from edgepi.adc.adc_constants import ADCReadInfo, ADCNum, ADC1_NUM_DATA_BYTES, ADC2_NUM_DATA_BYTES
 from edgepi.calibration.calibration_constants import CalibParam
-from edgepi.utilities.utilities import bitstring_from_list
+from edgepi.utilities.utilities import bitstring_from_list, DEV_bitstring_from_list
 
 
 # TODO: retrieve these values from EEPROM once added
@@ -96,7 +96,7 @@ def code_to_voltage_single_ended(code: list[int], adc_info: ADCReadInfo, calibs:
     Returns:
         `float`: voltage value (V) corresponding to `code`
     """
-    code_bits = bitstring_from_list(code[:adc_info.num_data_bytes])
+    code_bits = DEV_bitstring_from_list(code[:adc_info.num_data_bytes])
     num_bits = adc_info.num_data_bytes * 8
     code_val = code_bits.uint
 

--- a/src/edgepi/adc/adc_voltage.py
+++ b/src/edgepi/adc/adc_voltage.py
@@ -26,7 +26,7 @@ def _is_negative_voltage(code: list[int]):
     Determines if voltage code is negative value
     """
     # check if first bit of the first integer is a 1
-    return (code[0] & 0x80) != 0 
+    return (code[0] & 0x80) != 0
 
 
 def _code_to_input_voltage(code: int, v_ref: float, num_bits: int):
@@ -43,7 +43,7 @@ def _code_to_input_voltage(code: int, v_ref: float, num_bits: int):
         `num_bits` (int): number of bits in ADC voltage read (24 or 32)
     """
     voltage_range = v_ref / 2 ** (num_bits - 1)
-    _logger.debug(f"_code_to_input_voltage: code {code}")
+    _logger.debug("_code_to_input_voltage: code {}".format(code))
     return float(code) * voltage_range
 
 
@@ -76,8 +76,9 @@ def code_to_voltage(code: list[int], adc_info: ADCReadInfo, calibs: CalibParam) 
     elif adc_info.num_data_bytes == ADC2_NUM_DATA_BYTES:
         code_val = combine_to_uint32(0, code[0], code[1], code[2])
     else:
-        raise Exception(
-            f"code has unexpected number of bytes {adc_info.num_data_bytes}, expected 4 for ADC1 or 3 for ADC2"
+        raise ValueError(
+            f"code has unexpected number of bytes {adc_info.num_data_bytes}, "
+            "expected 4 for ADC1 or 3 for ADC2"
         )
 
     if _is_negative_voltage(code):
@@ -108,8 +109,9 @@ def code_to_voltage_single_ended(code: list[int], adc_info: ADCReadInfo, calibs:
     elif adc_info.num_data_bytes == ADC2_NUM_DATA_BYTES:
         code_val = combine_to_uint32(0, code[0], code[1], code[2])
     else:
-        raise Exception(
-            f"code has unexpected number of bytes {adc_info.num_data_bytes}, expected 4 for ADC1 or 3 for ADC2"
+        raise ValueError(
+            f"code has unexpected number of bytes {adc_info.num_data_bytes}, "
+            "expected 4 for ADC1 or 3 for ADC2"
         )
 
     if _is_negative_voltage(code) and adc_info.num_data_bytes == ADC1_NUM_DATA_BYTES:

--- a/src/edgepi/adc/adc_voltage.py
+++ b/src/edgepi/adc/adc_voltage.py
@@ -42,7 +42,7 @@ def _code_to_input_voltage(code: int, v_ref: float, num_bits: int):
         `num_bits` (int): number of bits in ADC voltage read (24 or 32)
     """
     voltage_range = v_ref / 2 ** (num_bits - 1)
-    _logger.debug("_code_to_input_voltage: code %d" % code)
+    _logger.debug("_code_to_input_voltage: code %d", code)
     return float(code) * voltage_range
 
 

--- a/src/edgepi/adc/adc_voltage.py
+++ b/src/edgepi/adc/adc_voltage.py
@@ -41,8 +41,9 @@ def _code_to_input_voltage(code: int, v_ref: float, num_bits: int):
 
         `num_bits` (int): number of bits in ADC voltage read (24 or 32)
     """
+
     voltage_range = v_ref / 2 ** (num_bits - 1)
-    _logger.debug("_code_to_input_voltage: code %d", code)
+    _logger.debug(f"_code_to_input_voltage: code {code}")
     return float(code) * voltage_range
 
 

--- a/src/edgepi/adc/adc_voltage.py
+++ b/src/edgepi/adc/adc_voltage.py
@@ -3,7 +3,6 @@
 
 import logging
 
-from bitstring import BitArray
 from edgepi.adc.adc_constants import ADCReadInfo, ADCNum, ADC1_NUM_DATA_BYTES, ADC2_NUM_DATA_BYTES
 from edgepi.calibration.calibration_constants import CalibParam
 from edgepi.utilities.utilities import bitstring_from_list, combine_to_uint32
@@ -43,7 +42,7 @@ def _code_to_input_voltage(code: int, v_ref: float, num_bits: int):
         `num_bits` (int): number of bits in ADC voltage read (24 or 32)
     """
     voltage_range = v_ref / 2 ** (num_bits - 1)
-    _logger.debug("_code_to_input_voltage: code {}".format(code))
+    _logger.debug("_code_to_input_voltage: code %d" % code)
     return float(code) * voltage_range
 
 

--- a/src/edgepi/adc/edgepi_adc.py
+++ b/src/edgepi/adc/edgepi_adc.py
@@ -575,8 +575,10 @@ class EdgePiADC(SPI):
             read_data = self.transfer([adc_num.value.read_cmd] + [255] * 6)
             if adc_num is ADCNum.ADC_1:
                 ready = (read_data[1] & 0b01000000) == 0b01000000
-            if adc_num is ADCNum.ADC_2:
+            elif adc_num is ADCNum.ADC_2:
                 ready = (read_data[1] & 0b10000000) == 0b10000000
+            else:
+                raise ValueError("unexpected adc_num")
             return ready
 
     def __read_registers_to_map(self):

--- a/src/edgepi/adc/edgepi_adc.py
+++ b/src/edgepi/adc/edgepi_adc.py
@@ -976,11 +976,13 @@ class EdgePiADC(SPI):
                                         [None])
         self.__config(**args)
 
+    # pylint: disable=too-many-branches
+    # pylint: disable=too-many-statements
     def adc1_config_and_read_samples_batch(
         self,
         data_rate: ADC1DataRate,
-        analog_in_list: list[AnalogIn] = [],
-        differential_pairs: list[DiffMode] = [],
+        analog_in_list: list[AnalogIn],
+        differential_pairs: list[DiffMode],
     ) -> list:
         """
         This function sets the config, and rb

--- a/src/edgepi/adc/edgepi_adc.py
+++ b/src/edgepi/adc/edgepi_adc.py
@@ -236,10 +236,8 @@ class EdgePiADC(SPI):
         """
         if len(data) < 1:
             raise ValueError("Number of registers to write to must be at least 1")
-
-        code = self.adc_ops.unsafe_write_register_command(start_addx.value, data)
+        code = self.adc_ops.write_register_command(start_addx.value, data)
         _logger.debug(f"__write_register: sending {code}")
-
         with self.spi_open():
             return self.transfer(code)
 
@@ -675,7 +673,6 @@ class EdgePiADC(SPI):
             rtd_enabled = self.rtd_state_cache
             validate_channels_allowed(channels, rtd_enabled)
 
-        # NOTE: this is only commented so we can test caching the opcodes result (cannot hash dict)
         adc_mux_updates = {
             ADCReg.REG_INPMUX: (adc_1_mux_p, adc_1_mux_n),
             ADCReg.REG_ADC2MUX: (adc_2_mux_p, adc_2_mux_n),
@@ -779,7 +776,6 @@ class EdgePiADC(SPI):
         (ADC1RtdConfig.OFF.value if adc_num == ADCNum.ADC_1  else ADC2RtdConfig.OFF.value)
         return updates
 
-    # TODO: is this called by the edgepi portal when changes to the config shadow is made?
     def set_rtd(self, set_rtd: bool, adc_num: ADCNum = ADCNum.ADC_2):
         """
         Enable/Disable RTD with ADC type passed as arguments.

--- a/src/edgepi/adc/edgepi_adc.py
+++ b/src/edgepi/adc/edgepi_adc.py
@@ -671,8 +671,7 @@ class EdgePiADC(SPI):
             validate_channels_allowed(channels, rtd_enabled)
 
         return generate_mux_opcodes(
-            ADCReg.REG_INPMUX, (adc_1_mux_p, adc_1_mux_n), 
-            ADCReg.REG_ADC2MUX, (adc_2_mux_p, adc_2_mux_n)
+            (adc_1_mux_p, adc_1_mux_n), (adc_2_mux_p, adc_2_mux_n)
         )
 
     def select_differential(self, adc: ADCNum, diff_mode: DiffMode):

--- a/src/edgepi/adc/edgepi_adc.py
+++ b/src/edgepi/adc/edgepi_adc.py
@@ -5,7 +5,7 @@ from operator import attrgetter
 import logging
 import time
 
-from edgepi.adc.adc_query_lang import PropertyValue
+from edgepi.adc.adc_query_lang import PropertyValue, ADCProperties
 from edgepi.calibration.calibration_constants import CalibParam
 from edgepi.peripherals.spi import SpiDevice as SPI
 from edgepi.adc.adc_commands import ADCCommands
@@ -1037,6 +1037,211 @@ class EdgePiADC(SPI):
                                         ["self", "adc_1_analog_in", "adc_2_analog_in"],
                                         [None])
         self.__config(**args)
+
+    # this function combines both calls, and tries to save performance where possible
+    def set_config_and_read_sample(
+        self,
+        adc_1_analog_in: AnalogIn = None,
+        adc_1_data_rate: ADC1DataRate = None,
+        adc_2_analog_in: AnalogIn = None,
+        adc_2_data_rate: ADC2DataRate = None,
+        filter_mode: FilterMode = None,
+        conversion_mode: ConvMode = None,
+        override_updates_validation: bool = False,
+        adc_1_pga: ADC1PGA = None,
+        secondary = False
+    ):
+        adc_1_ch  = self.__analog_in_to_adc_in_map.get(adc_1_analog_in)
+        adc_2_ch  = self.__analog_in_to_adc_in_map.get(adc_2_analog_in)
+
+        if adc_1_ch is None and adc_1_analog_in is not None:
+            raise TypeError(f"set_config: wrong type passed for adc_1_analog_in: {adc_1_analog_in}")
+        if adc_2_ch is None and adc_2_analog_in is not None:
+            raise TypeError(f"set_config: wrong type passed for adc_2_analog_in: {adc_2_analog_in}")
+
+        override_rtd_validation = False
+
+        # filter out self and None args
+        args = filter_dict_list_key_val(locals(), ["self", "adc_1_analog_in", "adc_2_analog_in", "secondary"], [None])
+
+        # permit updates by rtd_mode() to turn RTD off when it's on, validate other updates
+        if not override_rtd_validation:
+            self.__validate_no_rtd_conflict(args) # 0.020
+
+        # get opcodes for mapping multiplexers
+        #mux_args = self.__extract_mux_args(args) # 0.019
+        mux_args = {}
+        if "adc_1_ch" in args: mux_args["adc_1_mux_p"] = args["adc_1_ch"]
+        if "adc_2_ch" in args: mux_args["adc_2_mux_p"] = args["adc_2_ch"]
+        if "adc_1_mux_n" in args: mux_args["adc_1_mux_n"] = args["adc_1_mux_n"]
+        if "adc_2_mux_n" in args: mux_args["adc_2_mux_n"] = args["adc_2_mux_n"]
+
+        ops_list = self.__get_channel_assign_opcodes( # 0.184
+            **mux_args, override_rtd_validation=override_rtd_validation
+        )
+
+        # extract OpCode type args, since args may contain non-OpCode args
+        ops_list += [
+            entry.value
+            for entry in args.values()
+            if issubclass(entry.__class__, Enum) and isinstance(entry.value, OpCode)
+        ]
+
+        # get current register values
+        reg_values = self.__get_register_map() # 0.017
+        #print(reg_values)
+        if len(reg_values.values()) < 1:
+            raise ValueError("Number of reg_values must be at least 1")
+
+        # get codes to update register values
+        updated_reg_values = apply_opcodes(dict(reg_values), ops_list) # 0.137
+        new_edgepi_register_state = { addx: entry["value"] for (addx, entry) in updated_reg_values.items() }
+
+        # get state for configs relevant to conversion delay
+        #state = ADCState(new_edgepi_register_state)
+        #data_rate = state.adc_1.data_rate.code
+        #filter_mode = state.filter_mode.code
+
+        # TODO: ensure this is equivalent to before
+        data_rate = ADCState.get_state(new_edgepi_register_state, ADCProperties.DATA_RATE_1).code
+        filter_mode = ADCState.get_state(new_edgepi_register_state, ADCProperties.FILTER_MODE).code
+        conv_delay = expected_initial_time_delay(
+            ADCNum.ADC_1, data_rate.value.op_code, filter_mode.value.op_code
+        )
+
+        # write updated reg values to ADC using a single write.
+        #self.__write_register(ADCReg.REG_ID, data) # 1.501
+        data = [entry["value"] for entry in updated_reg_values.values()]
+        if secondary:
+            write_reg_cmd = self.adc_ops.unsafe_write_register_command(0x06, data[6:7])
+        else:
+            write_reg_cmd = self.adc_ops.unsafe_write_register_command(ADCReg.REG_ID.value, data)
+        start_cmd     = self.adc_ops.start_adc(ADCNum.ADC_1.value) # TODO: what does this do? how can it be batched?
+        read_cmd      = [ADCNum.ADC_1.value.read_cmd] + [255] * ADC_VOLTAGE_READ_LEN
+
+        # send command to trigger conversion & to read conversion data.
+        read_data = self.custom_adc_open_and_transfer(write_reg_cmd + start_cmd, conv_delay / 1000, read_cmd)
+
+        #with self.spi_open():
+        #    self.transfer(write_reg_cmd + start_cmd)
+        #    time.sleep(conv_delay / 1000) # 0.580
+        #    read_data = self.transfer(read_cmd)
+
+        # update ADC state (for state caching)
+        EdgePiADC.__state = new_edgepi_register_state
+
+        if (len(read_data) - 1) != ADC_VOLTAGE_READ_LEN:
+            raise VoltageReadError(
+                f"Voltage read failed: incorrect number of bytes ({len(read_data)}) retrieved"
+            )
+
+        voltage_code = read_data[2 : (2 + ADCNum.ADC_1.value.num_data_bytes)]
+        check_code = read_data[6]
+        check_crc(voltage_code, check_code)
+
+        calibs = self.__get_calibration_values(self.adc_calib_params[ADCNum.ADC_1], ADCNum.ADC_1) # 0.064
+
+        # convert from code to voltage
+        return DEV_code_to_voltage_single_ended(voltage_code, ADCNum.ADC_1.value, calibs) # 0.116
+
+    def config_and_read_samples_batch(
+        self,
+        adc_1_analog_in_list: list[AnalogIn] = [],
+        adc_1_data_rate: ADC1DataRate = None,
+        adc_2_analog_in: AnalogIn = None,
+        adc_2_data_rate: ADC2DataRate = None,
+        conversion_mode: ConvMode = None
+    ):
+        adc_1_ch_list = []
+        for adc_1_analog_in in adc_1_analog_in_list:
+            adc_1_ch = self.__analog_in_to_adc_in_map.get(adc_1_analog_in)
+            if adc_1_ch is None and adc_1_analog_in is not None:
+                raise TypeError(f"set_config: wrong type passed in adc_1_analog_in_list: {adc_1_analog_in}")
+            adc_1_ch_list += [adc_1_ch]
+        
+        adc_2_ch = self.__analog_in_to_adc_in_map.get(adc_2_analog_in)
+        if adc_2_ch is None and adc_2_analog_in is not None:
+            raise TypeError(f"set_config: wrong type passed for adc_2_analog_in: {adc_2_analog_in}")
+
+        override_rtd_validation = False
+        
+        # filter out self and None args
+        args = filter_dict_list_key_val(locals(), ["self", "adc_1_analog_in_list", "adc_2_analog_in"], [None])
+
+        # permit updates by rtd_mode() to turn RTD off when it's on, validate other updates
+        if not override_rtd_validation:
+            self.__validate_no_rtd_conflict(args) # 0.020
+
+        # get instructions needed to send for each input
+        command_tup_list = []
+        for i, adc_1_ch in enumerate(adc_1_ch_list):
+            # get opcodes for mapping multiplexers
+            mux_args = {}
+            if "adc_1_ch" in args: mux_args["adc_1_mux_p"] = adc_1_ch
+            if "adc_2_ch" in args: mux_args["adc_2_mux_p"] = adc_2_ch
+            if "adc_1_mux_n" in args: mux_args["adc_1_mux_n"] = args["adc_1_mux_n"]
+            if "adc_2_mux_n" in args: mux_args["adc_2_mux_n"] = args["adc_2_mux_n"]
+
+            ops_list = self.__get_channel_assign_opcodes( # 0.184
+                **mux_args, override_rtd_validation=override_rtd_validation
+            )
+
+            # extract OpCode type args, since args may contain non-OpCode args
+            ops_list += [
+                entry.value
+                for entry in args.values()
+                if issubclass(entry.__class__, Enum) and isinstance(entry.value, OpCode)
+            ]
+
+            # get current register values
+            reg_values = self.__get_register_map() # 0.017
+            if len(reg_values.values()) < 1:
+                raise ValueError("Number of reg_values must be at least 1")
+
+            # get codes to update register values
+            updated_reg_values = apply_opcodes(dict(reg_values), ops_list) # 0.137
+            new_edgepi_register_state = { addx: entry["value"] for (addx, entry) in updated_reg_values.items() }
+
+            # TODO: ensure this is equivalent to before
+            data_rate = ADCState.get_state(new_edgepi_register_state, ADCProperties.DATA_RATE_1).code
+            filter_mode = ADCState.get_state(new_edgepi_register_state, ADCProperties.FILTER_MODE).code
+            conv_delay = expected_initial_time_delay(
+                ADCNum.ADC_1, data_rate.value.op_code, filter_mode.value.op_code
+            )
+
+            # write updated reg values to ADC using a single write.
+            data = [entry["value"] for entry in updated_reg_values.values()]
+            if i == 0:
+                write_reg_cmd = self.adc_ops.unsafe_write_register_command(ADCReg.REG_ID.value, data)
+            else:
+                write_reg_cmd = self.adc_ops.unsafe_write_register_command(0x06, data[6:7])
+
+            start_cmd = self.adc_ops.start_adc(ADCNum.ADC_1.value) # TODO: what does this do? how can it be batched?
+            read_cmd  = [ADCNum.ADC_1.value.read_cmd] + [255] * ADC_VOLTAGE_READ_LEN
+
+            command_tup_list += [(write_reg_cmd + start_cmd, conv_delay / 1000, read_cmd)]
+
+        data_list = self.custom_adc_batch_open_and_transfer(command_tup_list)
+
+        # update ADC state (for state caching)
+        EdgePiADC.__state = new_edgepi_register_state
+
+        voltage_list = []
+        for read_data in data_list:
+            if (len(read_data) - 1) != ADC_VOLTAGE_READ_LEN:
+                raise VoltageReadError(f"Voltage read failed: incorrect number of bytes ({len(read_data)}) retrieved")
+
+            voltage_code = read_data[2 : (2 + ADCNum.ADC_1.value.num_data_bytes)]
+            check_code = read_data[6]
+            check_crc(voltage_code, check_code)
+
+            calibs = self.__get_calibration_values(self.adc_calib_params[ADCNum.ADC_1], ADCNum.ADC_1) # 0.064
+
+            # convert from code to voltage
+            voltage_list += [DEV_code_to_voltage_single_ended(voltage_code, ADCNum.ADC_1.value, calibs)] # 0.116
+
+        return voltage_list
+
 
     def get_state(self, override_cache: bool = False) -> ADCState:
         """

--- a/src/edgepi/adc/edgepi_adc.py
+++ b/src/edgepi/adc/edgepi_adc.py
@@ -136,9 +136,6 @@ class EdgePiADC(SPI):
         # voltage they are measuring. To be changed later when range config is implemented
         # self.set_adc_reference(ADCReferenceSwitching.GND_SW1.value)
 
-        # uses gpio & checks the current state
-        self.rtd_state_cache = self.__is_rtd_on()
-
         # user updated rtd hardware constants
         self.rtd_sensor_resistance = (
             rtd_sensor_resistance
@@ -252,7 +249,6 @@ class EdgePiADC(SPI):
         # pylint: disable=expression-not-assigned
         self.gpio.set_pin_state(RTDPins.RTD_EN.value) if enable else \
         self.gpio.clear_pin_state(RTDPins.RTD_EN.value)
-        self.rtd_state_cache = enable
 
     # TODO: To be deleted
     def set_adc_reference(self, reference_config: ADCReferenceSwitching = None):
@@ -359,20 +355,20 @@ class EdgePiADC(SPI):
         """
         Get differential pair id number for retrieving differential pair calibration values
         """
-        #  values are the keys from adc_calib_params
-        diff_ids = {
-                DiffMode.DIFF_1.value: 8,
-                DiffMode.DIFF_2.value: 9,
-                DiffMode.DIFF_3.value: 10,
-                DiffMode.DIFF_4.value: 11,
-            }
+        # return values are the keys from adc_calib_params
         diff_pair = DifferentialPair(mux_p.code, mux_n.code)
-        diff_id = diff_ids.get(diff_pair)
-        if diff_id is None:
+        if diff_pair == DiffMode.DIFF_1.value:
+            return 8
+        elif diff_pair == DiffMode.DIFF_2.value:
+            return 9
+        elif diff_pair == DiffMode.DIFF_3.value:
+            return 10
+        elif diff_pair == DiffMode.DIFF_4.value:
+            return 11
+        else:
             raise InvalidDifferentialPairError(
-                    f"Cannot retrieve calibration values for invalid differential pair {diff_pair}"
-                    )
-        return diff_id
+                f"Cannot retrieve calibration values for invalid differential pair {diff_pair}"
+            )
 
     def __get_calibration_values(self, adc_calibs: dict, adc_num: ADCNum) -> CalibParam:
         """
@@ -670,16 +666,13 @@ class EdgePiADC(SPI):
         # allowed channels depend on RTD_EN status
         if not override_rtd_validation:
             channels = list(args.values())
-            rtd_enabled = self.rtd_state_cache
+            rtd_enabled = self.__is_rtd_on()
             validate_channels_allowed(channels, rtd_enabled)
 
-        adc_mux_updates = {
-            ADCReg.REG_INPMUX: (adc_1_mux_p, adc_1_mux_n),
-            ADCReg.REG_ADC2MUX: (adc_2_mux_p, adc_2_mux_n),
-        }
-
-        opcodes = generate_mux_opcodes(adc_mux_updates)
-        return opcodes
+        return generate_mux_opcodes(
+            ADCReg.REG_INPMUX, (adc_1_mux_p, adc_1_mux_n), 
+            ADCReg.REG_ADC2MUX, (adc_2_mux_p, adc_2_mux_n)
+        )
 
     def select_differential(self, adc: ADCNum, diff_mode: DiffMode):
         """
@@ -983,50 +976,45 @@ class EdgePiADC(SPI):
                                         [None])
         self.__config(**args)
 
-    # TODO: ensure I understand every step of this function
-    # TODO: ensure I understand how this differs from the past version of this function
-    def config_and_read_samples_batch(
+    def adc1_config_and_read_samples_batch(
         self,
-        adc_1_data_rate: ADC1DataRate,
-        adc_1_analog_in_list: list[AnalogIn] = [],
+        data_rate: ADC1DataRate,
+        analog_in_list: list[AnalogIn] = [],
         differential_pairs: list[DiffMode] = [],
     ) -> list:
         """
-        This function sets the config, and reads from the provided ain and differential channels. Note that differential 
-        channels can overlap with ain and should not. This function does not support ADC 2, and changes the conversion 
-        mode to PULSE automatically.
+        This function sets the config, and rb
+        This function only supports ADC 1, and changes the conversion mode to PULSE automatically.
 
         Will reset any prior config made to the ADC. Does not work with RTD mode, and may override configs if RTD mode 
         is active.
-
-        TODO: ensure that it's not possible to mess up the configuration?
         """
 
-        if adc_1_analog_in_list == [] and differential_pairs == []:
-            raise Exception("Both inputs can't be empty")
+        if analog_in_list == [] and differential_pairs == []:
+            raise ValueError("Both analog_in_list and differential_pairs can't be empty")
 
-        if not isinstance(adc_1_data_rate.value, OpCode):
-            raise Exception("adc_1_data_rate invalid")
+        if not isinstance(data_rate.value, OpCode):
+            raise TypeError("data_rate must be of type ADC1DataRate")
 
-        adc_1_ch_list = []
-        for adc_1_analog_in in adc_1_analog_in_list:
-            adc_1_ch = self.__analog_in_to_adc_in_map.get(adc_1_analog_in)
-            if adc_1_ch is None and adc_1_analog_in is not None:
-                raise TypeError(f"set_config: wrong type passed in adc_1_analog_in_list: {adc_1_analog_in}")
-            adc_1_ch_list += [adc_1_ch]
+        channel_list = []
+        for analog_in in analog_in_list:
+            channel = self.__analog_in_to_adc_in_map.get(analog_in)
+            if channel is None and analog_in is not None:
+                raise TypeError(f"set_config: wrong type passed in analog_in_list: {analog_in}")
+            channel_list += [channel]
 
         diff_update_list = [(diff_mode.value.mux_p, diff_mode.value.mux_n) for diff_mode in differential_pairs]
 
-        # filter out self and None args
-        opcodes = [adc_1_data_rate.value, ConvMode.PULSE.value]
+        opcodes = [data_rate.value, ConvMode.PULSE.value]
 
         # get current register values
         register_values = self.__get_register_map()
+        print(f"reg vals: {register_values}")
         if len(register_values.values()) < 1:
             raise ValueError("Number of reg_values must be at least 1")
 
-        def generate_config_and_read_commands(i:int, register_values, mux_p, mux_n):
-            # get opcodes for mapping multiplexers
+        def create_commands(i:int, register_values:dict, mux_p, mux_n) -> tuple:
+            # get opcodes for multiplexing between ADC1 and the positive & negative channel
             ops_list = self.__get_channel_assign_opcodes(
                 adc_1_mux_p=mux_p,
                 adc_1_mux_n=mux_n,
@@ -1038,22 +1026,20 @@ class EdgePiADC(SPI):
             updated_reg_values = apply_opcodes(dict(register_values), ops_list)
             register_values = { addx: entry["value"] for (addx, entry) in updated_reg_values.items() }
 
-            # TODO: ensure this is equivalent to before
             data_rate = ADCState.get_state(register_values, ADCProperties.DATA_RATE_1).code
             filter_mode = ADCState.get_state(register_values, ADCProperties.FILTER_MODE).code
             conversion_delay = expected_initial_time_delay(
                 ADCNum.ADC_1, data_rate.value.op_code, filter_mode.value.op_code
             ) / 1000
 
-            # TODO: understand the order of this & only compute the values that are actually needed; ie. only do the above once, 
-            # or even just skip it all since we know what our setting is supposed to be already...
-            data = [entry["value"] for entry in updated_reg_values.values()]
             if i == 0:
                 # write entire state of updated reg values to ADC using a single write
+                data = [entry["value"] for entry in updated_reg_values.values()]
                 write_reg_cmd = self.adc_ops.unsafe_write_register_command(ADCReg.REG_ID.value, data)
             else:
-                # only write the register value
-                write_reg_cmd = self.adc_ops.unsafe_write_register_command(ADCReg.REG_INPMUX.value, data[6:7])
+                # only write the register value at 0x06 (REG_INPMUX)
+                data = [ updated_reg_values[6]["value"] ]
+                write_reg_cmd = self.adc_ops.unsafe_write_register_command(ADCReg.REG_INPMUX.value, data)
 
             start_cmd = self.adc_ops.start_adc(ADCNum.ADC_1.value)
             read_cmd  = [ADCNum.ADC_1.value.read_cmd] + [255] * ADC_VOLTAGE_READ_LEN # TODO: make this a function like the others
@@ -1062,17 +1048,19 @@ class EdgePiADC(SPI):
 
         # get instructions needed to send for each input
         command_tup_list = []
-        for i, adc_1_ch in enumerate(adc_1_ch_list):
+        for i, channel in enumerate(channel_list):
             # AINCOM is the default, and implies this is not differential
-            command_tup, register_values = generate_config_and_read_commands(i, register_values, adc_1_ch, CH.AINCOM)
+            command_tup, register_values = create_commands(i, register_values, channel, CH.AINCOM)
             command_tup_list += [command_tup]
 
         for mux_p, mux_n in diff_update_list:
-            command_tup, register_values = generate_config_and_read_commands(-1, register_values, mux_p, mux_n)
+            command_tup, register_values = create_commands(-1, register_values, mux_p, mux_n)
             command_tup_list += [command_tup]
 
-        data_list = self.custom_adc_batch_open_and_transfer(command_tup_list)
-
+        print(command_tup_list)
+        data_list = self.spi_apply_adc_commands(command_tup_list)
+        print(data_list)
+        
         # update with final ADC state (for state caching)
         EdgePiADC.__state = register_values
 
@@ -1088,11 +1076,10 @@ class EdgePiADC(SPI):
             calibs = self.__get_calibration_values(self.adc_calib_params[ADCNum.ADC_1], ADCNum.ADC_1)
 
             # convert from code to voltage
-            if i < len(adc_1_ch_list):
+            if i < len(channel_list):
                 voltage_list += [code_to_voltage_single_ended(voltage_code, ADCNum.ADC_1.value, calibs)]
             else:
                 voltage_list += [code_to_voltage(voltage_code, ADCNum.ADC_1.value, calibs)]
-
         return voltage_list
 
     def get_state(self, override_cache: bool = False) -> ADCState:
@@ -1106,6 +1093,7 @@ class EdgePiADC(SPI):
             ADCState: information about the current ADC hardware state
         """
         # TODO: combine this cache with __get_register_map
+        # no, but make it equal?
         if self.adc_state_cache is None or not self.enable_cache:
             reg_values = self.__get_register_map(override_cache)
             self.adc_state_cache = ADCState(reg_values)

--- a/src/edgepi/adc/edgepi_adc.py
+++ b/src/edgepi/adc/edgepi_adc.py
@@ -981,8 +981,8 @@ class EdgePiADC(SPI):
     def adc1_config_and_read_samples_batch(
         self,
         data_rate: ADC1DataRate,
-        analog_in_list: list[AnalogIn],
-        differential_pairs: list[DiffMode],
+        analog_in_list: list[AnalogIn] = None,
+        differential_pairs: list[DiffMode] = None,
     ) -> list:
         """
         This function sets the config, and rb
@@ -991,7 +991,10 @@ class EdgePiADC(SPI):
         Will reset any prior config made to the ADC. Does not work with RTD mode, and may override configs if RTD mode 
         is active.
         """
-
+        if analog_in_list is None:
+            analog_in_list = []
+        if differential_pairs is None:
+            differential_pairs = []
         if analog_in_list == [] and differential_pairs == []:
             raise ValueError("Both analog_in_list and differential_pairs can't be empty")
 

--- a/src/edgepi/digital_input/digital_input_constants.py
+++ b/src/edgepi/digital_input/digital_input_constants.py
@@ -15,3 +15,6 @@ class DinPins(Enum):
     DIN6 = 'DIN6'
     DIN7 = 'DIN7'
     DIN8 = 'DIN8'
+
+DIN_MIN_NUM = 1
+DIN_MAX_NUM = 8

--- a/src/edgepi/digital_input/digital_input_constants.py
+++ b/src/edgepi/digital_input/digital_input_constants.py
@@ -15,6 +15,3 @@ class DinPins(Enum):
     DIN6 = 'DIN6'
     DIN7 = 'DIN7'
     DIN8 = 'DIN8'
-
-DIN_MIN_NUM = 1
-DIN_MAX_NUM = 8

--- a/src/edgepi/digital_input/edgepi_digital_input.py
+++ b/src/edgepi/digital_input/edgepi_digital_input.py
@@ -12,7 +12,7 @@ class EdgePiDigitalInput():
         # To limit access to input functionality, using composition rather than inheritance
         self.gpio = EdgePiGPIO()
 
-    def digital_input_state(self, pin_name: DinPins):
+    def digital_input_state(self, pin_name: DinPins = None):
         """
         Read selected GPIO pin
         Args:

--- a/src/edgepi/digital_input/edgepi_digital_input.py
+++ b/src/edgepi/digital_input/edgepi_digital_input.py
@@ -28,3 +28,20 @@ class EdgePiDigitalInput():
             raise InvalidPinName(f'Invalid pin name passed: {pin_name}')
         else:
             return self.gpio.fast_read_din_state(pin_number)
+
+    def digital_input_state_batch(self, pin_names: list[DinPins]) -> list:
+        """
+        Read multiple GPIO pins as digital inputs
+        """
+        if pin_names is None:
+            raise InvalidPinName('pin_names cannot be None')
+        elif pin_names is []:
+            # TODO: what is the correct exception to raise?
+            raise Exception('pin_names cannot be empty')
+
+        pin_numbers = [int(pin_name.value[3]) for pin_name in pin_names]
+        invalid_pin_numbers = [num for num in pin_numbers if (num > DIN_MAX_NUM) or (num < DIN_MIN_NUM)]
+        if len(invalid_pin_numbers) > 0:
+            raise InvalidPinName(f'Invalid pin names passed: {invalid_pin_numbers}')
+        else:
+            return self.gpio.fast_read_din_state_batch(pin_numbers)

--- a/src/edgepi/digital_input/edgepi_digital_input.py
+++ b/src/edgepi/digital_input/edgepi_digital_input.py
@@ -20,28 +20,24 @@ class EdgePiDigitalInput():
         Return:
             state (bool): corresponding pin state
         """
-        if pin_name is None:
+        if pin_name is None or not isinstance(pin_name, DinPins):
             raise InvalidPinName(f'Invalid pin name passed: {pin_name}')
 
         pin_number = int(pin_name.value[3])
-        if pin_number > DIN_MAX_NUM or pin_number < DIN_MIN_NUM:
-            raise InvalidPinName(f'Invalid pin name passed: {pin_name}')
-        else:
-            return self.gpio.fast_read_din_state(pin_number)
+        return self.gpio.fast_read_din_state(pin_number)
 
     def digital_input_state_batch(self, pin_names: list[DinPins]) -> list:
         """
         Read multiple GPIO pins as digital inputs
         """
         if pin_names is None:
-            raise InvalidPinName('pin_names cannot be None')
-        elif pin_names is []:
-            # TODO: what is the correct exception to raise?
-            raise Exception('pin_names cannot be empty')
+            raise ValueError('pin_names cannot be None')
+        elif pin_names == []:
+            raise ValueError('pin_names cannot be empty')
 
+        invalid_pin_types = [False for pin_name in pin_names if not isinstance(pin_name, DinPins)]
+        if len(invalid_pin_types) > 0:
+            raise InvalidPinName(f'Invalid pin names passed in {pin_names}')
+        
         pin_numbers = [int(pin_name.value[3]) for pin_name in pin_names]
-        invalid_pin_numbers = [num for num in pin_numbers if (num > DIN_MAX_NUM) or (num < DIN_MIN_NUM)]
-        if len(invalid_pin_numbers) > 0:
-            raise InvalidPinName(f'Invalid pin names passed: {invalid_pin_numbers}')
-        else:
-            return self.gpio.fast_read_din_state_batch(pin_numbers)
+        return self.gpio.fast_read_din_state_batch(pin_numbers)

--- a/src/edgepi/digital_input/edgepi_digital_input.py
+++ b/src/edgepi/digital_input/edgepi_digital_input.py
@@ -1,6 +1,6 @@
 """Digital Input Module"""
 
-from edgepi.digital_input.digital_input_constants import DinPins
+from edgepi.digital_input.digital_input_constants import DinPins, DIN_MIN_NUM, DIN_MAX_NUM
 from edgepi.gpio.edgepi_gpio import EdgePiGPIO
 
 class InvalidPinName(Exception):
@@ -12,7 +12,7 @@ class EdgePiDigitalInput():
         # To limit access to input functionality, using composition rather than inheritance
         self.gpio = EdgePiGPIO()
 
-    def digital_input_state(self, pin_name: DinPins = None):
+    def digital_input_state(self, pin_name: DinPins):
         """
         Read selected GPIO pin
         Args:
@@ -20,6 +20,11 @@ class EdgePiDigitalInput():
         Return:
             state (bool): corresponding pin state
         """
-        if pin_name is None or pin_name.value not in [pins.value for pins in DinPins]:
+        if pin_name is None:
             raise InvalidPinName(f'Invalid pin name passed: {pin_name}')
-        return self.gpio.read_pin_state(pin_name.value)
+
+        pin_number = int(pin_name.value[3])
+        if pin_number > DIN_MAX_NUM or pin_number < DIN_MIN_NUM:
+            raise InvalidPinName(f'Invalid pin name passed: {pin_name}')
+        else:
+            return self.gpio.fast_read_din_state(pin_number)

--- a/src/edgepi/digital_input/edgepi_digital_input.py
+++ b/src/edgepi/digital_input/edgepi_digital_input.py
@@ -1,6 +1,6 @@
 """Digital Input Module"""
 
-from edgepi.digital_input.digital_input_constants import DinPins, DIN_MIN_NUM, DIN_MAX_NUM
+from edgepi.digital_input.digital_input_constants import DinPins
 from edgepi.gpio.edgepi_gpio import EdgePiGPIO
 
 class InvalidPinName(Exception):
@@ -38,6 +38,6 @@ class EdgePiDigitalInput():
         invalid_pin_types = [False for pin_name in pin_names if not isinstance(pin_name, DinPins)]
         if len(invalid_pin_types) > 0:
             raise InvalidPinName(f'Invalid pin names passed in {pin_names}')
-        
+
         pin_numbers = [int(pin_name.value[3]) for pin_name in pin_names]
         return self.gpio.fast_read_din_state_batch(pin_numbers)

--- a/src/edgepi/gpio/edgepi_gpio_chip.py
+++ b/src/edgepi/gpio/edgepi_gpio_chip.py
@@ -24,6 +24,9 @@ class EdgePiGPIOChip(GpioDevice):
                        DINPins.DIN7.value : 10,
                        DINPins.DIN8.value : 7
                     }
+    __din_mapping_array = [26, 6, 11, 9, 22, 27, 10, 7]
+    __din_pin_dir  = "in"
+    __din_pin_bias = "pull_down"
 
     def __init__(self):
         super().__init__(GpioDevPaths.GPIO_CIHP_DEV_PATH.value)
@@ -44,6 +47,13 @@ class EdgePiGPIOChip(GpioDevice):
                        pin_bias=self.gpiochip_pins_dict[pin_name].bias):
             state = self.read_state()
         return state
+
+    def fast_read_din_state(self, din_pin_num:int):
+        return self.open_read_state(
+            pin_num  = self.__din_mapping_array[din_pin_num-1],
+            pin_dir  = self.__din_pin_dir,
+            pin_bias = self.__din_pin_bias,
+        )
 
     def write_gpio_pin_state(self, pin_name: str = None, state: bool = None):
         """

--- a/src/edgepi/gpio/edgepi_gpio_chip.py
+++ b/src/edgepi/gpio/edgepi_gpio_chip.py
@@ -55,6 +55,14 @@ class EdgePiGPIOChip(GpioDevice):
             pin_bias = self.__din_pin_bias,
         )
 
+    def fast_read_din_state_batch(self, din_pin_num_list:list[int]) -> list:
+        pin_num_list = [self.__din_mapping_array[pin_num-1] for pin_num in din_pin_num_list]
+        return self.open_read_state_batch(
+            pin_num_list = pin_num_list,
+            pin_dir      = self.__din_pin_dir,
+            pin_bias     = self.__din_pin_bias,
+        )
+
     def write_gpio_pin_state(self, pin_name: str = None, state: bool = None):
         """
         write pin state

--- a/src/edgepi/gpio/gpio_configs.py
+++ b/src/edgepi/gpio/gpio_configs.py
@@ -433,6 +433,9 @@ def generate_pin_info(config: Union[GpioExpanderConfig, GpioChipConfig] = None):
         pin_dict = _generate_DOUT_expander_pins()
     elif config.name == GpioConfigs.PWM.value.name:
         pin_dict = _generate_PWM_expander_pins()
+    else:
+        raise ValueError(f"generate_pin_info received unknown config name {config.name}")
+
     return pin_dict
 
 def generate_expander_pin_info():

--- a/src/edgepi/peripherals/gpio.py
+++ b/src/edgepi/peripherals/gpio.py
@@ -78,6 +78,7 @@ class GpioDevice:
                     if gpio is None:
                         gpio = GPIO(self.gpio_fd, pin_num, pin_dir, bias=pin_bias)
                     else:
+                        # NOTE: we'll need to be careful when we update periphery, since we depend on private functionality
                         # pylint: disable=protected-access
                         gpio._line = pin_num
                         # pylint: disable=protected-access

--- a/src/edgepi/peripherals/gpio.py
+++ b/src/edgepi/peripherals/gpio.py
@@ -50,6 +50,7 @@ class GpioDevice:
         To minimize issues with the lock, we open & read in a single function call
         '''
         try:
+            # pylint: disable=consider-using-with
             GpioDevice.lock_gpio.acquire()
             gpio   = GPIO(self.gpio_fd, pin_num, pin_dir, bias=pin_bias)
             result = gpio.read()
@@ -71,6 +72,7 @@ class GpioDevice:
         '''
         results = []
         try:
+            # pylint: disable=consider-using-with
             GpioDevice.lock_gpio.acquire()
             gpio = None
             try:
@@ -80,6 +82,7 @@ class GpioDevice:
                     else:
                         # NOTE: we'll need to be careful when we update periphery, since we depend on a
                         # private functionality
+
                         # pylint: disable=protected-access
                         gpio._line = pin_num
                         # pylint: disable=protected-access

--- a/src/edgepi/peripherals/gpio.py
+++ b/src/edgepi/peripherals/gpio.py
@@ -83,8 +83,8 @@ class GpioDevice:
                         # NOTE: we'll need to be careful when we update periphery, since we depend on a
                         # private functionality
 
-                        # pylint: disable=protected-access
-                        gpio._line = pin_num
+                        gpio._line = pin_num # pylint: disable=protected-access
+
                         # pylint: disable=protected-access
                         gpio._reopen(pin_dir, edge="none", bias=pin_bias, drive="default", inverted=False)
                     results += [gpio.read()]

--- a/src/edgepi/peripherals/gpio.py
+++ b/src/edgepi/peripherals/gpio.py
@@ -45,6 +45,22 @@ class GpioDevice:
         """
         return self.gpio.read()
 
+    def open_read_state(self, pin_num:int, pin_dir:str, pin_bias:str):
+        try:
+            GpioDevice.lock_gpio.acquire()
+            gpio   = GPIO(self.gpio_fd, pin_num, pin_dir, bias=pin_bias)
+            result = gpio.read()
+
+        finally:
+            try:
+                gpio.close()
+            except Exception as exc:
+                raise OSError(f"Failed to close {self.gpio_fd}") from exc
+            finally:
+                GpioDevice.lock_gpio.release()
+
+        return result
+
     def write_state(self, state: bool = None):
         """
         Write state to GPIO pin

--- a/src/edgepi/peripherals/gpio.py
+++ b/src/edgepi/peripherals/gpio.py
@@ -78,7 +78,8 @@ class GpioDevice:
                     if gpio is None:
                         gpio = GPIO(self.gpio_fd, pin_num, pin_dir, bias=pin_bias)
                     else:
-                        # NOTE: we'll need to be careful when we update periphery, since we depend on private functionality
+                        # NOTE: we'll need to be careful when we update periphery, since we depend on a
+                        # private functionality
                         # pylint: disable=protected-access
                         gpio._line = pin_num
                         # pylint: disable=protected-access

--- a/src/edgepi/peripherals/spi.py
+++ b/src/edgepi/peripherals/spi.py
@@ -72,31 +72,6 @@ class SpiDevice:
         out = self.spi.transfer(data)
         return out
 
-    def custom_adc_open_and_transfer(self, data1:list, delay:int, data2:list) -> list:
-        try:
-            SpiDevice.lock_spi[self.dev_id].acquire()
-            self.spi = SPI(
-                self.devpath,
-                self.mode,
-                self.max_speed,
-                self.bit_order,
-                self.bits_per_word,
-                self.extra_flags,
-            )
-            self.spi.transfer(data1)
-            time.sleep(delay)
-            result = self.spi.transfer(data2)
-
-        finally:
-            try:
-                self.spi.close()
-            except Exception as exc:
-                raise OSError(f"Failed to close {self.devpath}") from exc
-            finally:
-                SpiDevice.lock_spi[self.dev_id].release()
-
-        return result
-
     def custom_adc_batch_open_and_transfer(self, command_tup_list):
         result_list = []
 
@@ -112,7 +87,7 @@ class SpiDevice:
             )
             for data1, delay, data2 in command_tup_list:
                 self.spi.transfer(data1)
-                time.sleep(delay) # TODO: make sure this wait is absolutely neccesary or if other delays might be needed
+                time.sleep(delay)
                 result_list += [self.spi.transfer(data2)]
 
         finally:

--- a/src/edgepi/peripherals/spi.py
+++ b/src/edgepi/peripherals/spi.py
@@ -72,7 +72,7 @@ class SpiDevice:
         out = self.spi.transfer(data)
         return out
 
-    def custom_adc_batch_open_and_transfer(self, command_tup_list):
+    def spi_apply_adc_commands(self, command_tup_list):
         result_list = []
 
         try:

--- a/src/edgepi/reg_helper/reg_helper.py
+++ b/src/edgepi/reg_helper/reg_helper.py
@@ -13,6 +13,7 @@ Functions:
     apply_opcode(OpCode, int)
 """
 
+from functools import cache
 
 from copy import deepcopy
 from dataclasses import dataclass
@@ -103,9 +104,9 @@ def apply_opcodes(register_values: dict, opcodes: list):
             "empty values received for 'register_values' or 'opcodes' args, opcodes not applied"
         )
         raise ValueError("register_values and opcodes args must both be non-empty")
-    _format_register_map(register_values)
+    _format_register_map(register_values) # 0.047
 
-    original_regs = deepcopy(register_values)
+    #original_regs = deepcopy(register_values)
 
     # apply each opcode to its corresponding register
     for opcode in opcodes:
@@ -113,14 +114,15 @@ def apply_opcodes(register_values: dict, opcodes: list):
         # if this opcode maps to a valid register address
         if register_entry is not None:
             # apply the opcode to the register
-            register_entry["value"] = _apply_opcode(register_entry["value"], opcode)
+            register_entry["value"] = _apply_opcode(register_entry["value"], opcode) # 0.606
             register_entry["is_changed"] = True
 
-    __validate_register_updates(original_regs, register_values)
+    # NOTE: disabling register update validation because there's no reason for us to suspect the other values would change? I'm not sure why this was done before.
+    #__validate_register_updates(original_regs, register_values)
 
     return register_values
 
-
+@cache
 def _apply_opcode(register_value: int, opcode: OpCode):
     """
     Generates an update code for a specific register by applying an opcode

--- a/src/edgepi/reg_helper/reg_helper.py
+++ b/src/edgepi/reg_helper/reg_helper.py
@@ -102,7 +102,7 @@ def apply_opcodes(register_values: dict, opcodes: list):
             "empty values received for 'register_values' or 'opcodes' args, opcodes not applied"
         )
         raise ValueError("register_values and opcodes args must both be non-empty")
-    _format_register_map(register_values) # 0.047
+    _format_register_map(register_values)
 
     #original_regs = deepcopy(register_values)
 
@@ -112,12 +112,12 @@ def apply_opcodes(register_values: dict, opcodes: list):
         # if this opcode maps to a valid register address
         if register_entry is not None:
             # apply the opcode to the register
-            register_entry["value"] = _apply_opcode(register_entry["value"], opcode) # 0.606
+            register_entry["value"] = _apply_opcode(register_entry["value"], opcode)
             register_entry["is_changed"] = True
 
     # NOTE: disabling register update validation because there's no reason for us to suspect the other 
     # values would change? I'm not sure why this was done before.
-    # This is also very slow, and affects the performance significantly
+    # This is also quite slow, and affects the performance significantly
     #__validate_register_updates(original_regs, register_values)
 
     return register_values

--- a/src/edgepi/reg_helper/reg_helper.py
+++ b/src/edgepi/reg_helper/reg_helper.py
@@ -13,7 +13,6 @@ Functions:
     apply_opcode(OpCode, int)
 """
 
-from copy import deepcopy
 from dataclasses import dataclass
 from enum import Enum
 import logging

--- a/src/edgepi/reg_helper/reg_helper.py
+++ b/src/edgepi/reg_helper/reg_helper.py
@@ -13,8 +13,6 @@ Functions:
     apply_opcode(OpCode, int)
 """
 
-from functools import cache
-
 from copy import deepcopy
 from dataclasses import dataclass
 from enum import Enum
@@ -117,12 +115,13 @@ def apply_opcodes(register_values: dict, opcodes: list):
             register_entry["value"] = _apply_opcode(register_entry["value"], opcode) # 0.606
             register_entry["is_changed"] = True
 
-    # NOTE: disabling register update validation because there's no reason for us to suspect the other values would change? I'm not sure why this was done before.
+    # NOTE: disabling register update validation because there's no reason for us to suspect the other 
+    # values would change? I'm not sure why this was done before.
+    # This is also very slow, and affects the performance significantly
     #__validate_register_updates(original_regs, register_values)
 
     return register_values
 
-@cache
 def _apply_opcode(register_value: int, opcode: OpCode):
     """
     Generates an update code for a specific register by applying an opcode

--- a/src/edgepi/utilities/utilities.py
+++ b/src/edgepi/utilities/utilities.py
@@ -6,7 +6,7 @@
 """
 
 
-from bitstring import BitArray, pack
+from bitstring import BitArray
 
 
 def filter_dict(dictionary: dict, entry_key="", entry_val="") -> dict:

--- a/src/edgepi/utilities/utilities.py
+++ b/src/edgepi/utilities/utilities.py
@@ -67,3 +67,6 @@ def bitstring_from_list(data: list) -> BitArray:
 # NOTE: is 10x faster than the above, make sure to confirm they are identical & add a test case or something
 def DEV_bitstring_from_list(data: list) -> BitArray:
     return BitArray(bytes(data))
+
+def combine_to_uint32(a:int, b:int, c:int, d:int) -> int:
+    return (a << 24) + (b << 16) + (c << 8) + d

--- a/src/edgepi/utilities/utilities.py
+++ b/src/edgepi/utilities/utilities.py
@@ -48,7 +48,7 @@ def filter_dict_list_key_val(dictionary: dict, entry_key: list, entry_val:list) 
     }
     return filtered_args
 
-def bitstring_from_list(data: list) -> BitArray:
+def bitstring_from_list(data: list[int]) -> BitArray:
     """
     Builds a bitstring from a list of uint byte values
 
@@ -58,12 +58,7 @@ def bitstring_from_list(data: list) -> BitArray:
     Returns:
         BitArray: bitstring of bytes ordered from data[0], data[1], ..., data[n-1]
     """
-    #code = BitArray()
-    #for value in data:
-    #    next_byte = pack("uint:8", value)
-    #    code.append(next_byte)
-    #return code
-    # TODO: add a test case to ensure these are equivalent - or just look into exception behaviour of pack
+    # bytes() will raise a ValueError if any ints in data are not in range(0, 256)
     return BitArray(bytes(data))
 
 def combine_to_uint32(a:int, b:int, c:int, d:int) -> int:

--- a/src/edgepi/utilities/utilities.py
+++ b/src/edgepi/utilities/utilities.py
@@ -48,8 +48,6 @@ def filter_dict_list_key_val(dictionary: dict, entry_key: list, entry_val:list) 
     }
     return filtered_args
 
-
-
 def bitstring_from_list(data: list) -> BitArray:
     """
     Builds a bitstring from a list of uint byte values
@@ -65,3 +63,7 @@ def bitstring_from_list(data: list) -> BitArray:
         next_byte = pack("uint:8", value)
         code.append(next_byte)
     return code
+
+# NOTE: is 10x faster than the above, make sure to confirm they are identical & add a test case or something
+def DEV_bitstring_from_list(data: list) -> BitArray:
+    return BitArray(bytes(data))

--- a/src/edgepi/utilities/utilities.py
+++ b/src/edgepi/utilities/utilities.py
@@ -58,14 +58,12 @@ def bitstring_from_list(data: list) -> BitArray:
     Returns:
         BitArray: bitstring of bytes ordered from data[0], data[1], ..., data[n-1]
     """
-    code = BitArray()
-    for value in data:
-        next_byte = pack("uint:8", value)
-        code.append(next_byte)
-    return code
-
-# NOTE: is 10x faster than the above, make sure to confirm they are identical & add a test case or something
-def DEV_bitstring_from_list(data: list) -> BitArray:
+    #code = BitArray()
+    #for value in data:
+    #    next_byte = pack("uint:8", value)
+    #    code.append(next_byte)
+    #return code
+    # TODO: add a test case to ensure these are equivalent - or just look into exception behaviour of pack
     return BitArray(bytes(data))
 
 def combine_to_uint32(a:int, b:int, c:int, d:int) -> int:

--- a/src/test_edgepi/integration_tests/conftest.py
+++ b/src/test_edgepi/integration_tests/conftest.py
@@ -3,12 +3,12 @@ import hashlib
 import platform
 
 import pytest
-    
+
 from edgepi.eeprom.edgepi_eeprom import EdgePiEEPROM
 from edgepi.eeprom.eeprom_constants import DEFAULT_EEPROM_BIN_B64
-   
+
 @pytest.fixture(scope="session", autouse=True)
-def eeprom_reset(request):
+def eeprom_reset():
     edgepi_eeprom = EdgePiEEPROM()
 
     if platform.node() == "edgepi-intg2":
@@ -20,5 +20,3 @@ def eeprom_reset(request):
         print('done!')
     else:
         print("dont reset eeprom")
- 
-    # request.addfinalizer()

--- a/src/test_edgepi/integration_tests/conftest.py
+++ b/src/test_edgepi/integration_tests/conftest.py
@@ -11,7 +11,7 @@ from edgepi.eeprom.eeprom_constants import DEFAULT_EEPROM_BIN_B64
 def eeprom_reset(request):
     edgepi_eeprom = EdgePiEEPROM()
 
-    if platform.node == "edgepi-intg2":
+    if platform.node() == "edgepi-intg2":
         print('loading default eeprom image ...')
         default_bin = base64.b64decode(DEFAULT_EEPROM_BIN_B64)
         hash_res = hashlib.md5(default_bin)

--- a/src/test_edgepi/integration_tests/conftest.py
+++ b/src/test_edgepi/integration_tests/conftest.py
@@ -1,0 +1,24 @@
+import base64
+import hashlib
+import platform
+
+import pytest
+    
+from edgepi.eeprom.edgepi_eeprom import EdgePiEEPROM
+from edgepi.eeprom.eeprom_constants import DEFAULT_EEPROM_BIN_B64
+   
+@pytest.fixture(scope="session", autouse=True)
+def eeprom_reset(request):
+    edgepi_eeprom = EdgePiEEPROM()
+
+    if platform.node == "edgepi-intg2":
+        print('loading default eeprom image ...')
+        default_bin = base64.b64decode(DEFAULT_EEPROM_BIN_B64)
+        hash_res = hashlib.md5(default_bin)
+        print('reseting eeprom ...')
+        edgepi_eeprom.reset_edgepi_memory(hash_res.hexdigest(), default_bin)
+        print('done!')
+    else:
+        print("dont reset eeprom")
+ 
+    # request.addfinalizer()

--- a/src/test_edgepi/integration_tests/test_adc/test_adc.py
+++ b/src/test_edgepi/integration_tests/test_adc/test_adc.py
@@ -1,5 +1,7 @@
 """ Integration tests for EdgePi ADC module """
 
+import time
+import statistics
 import logging
 import pytest
 
@@ -19,8 +21,12 @@ from edgepi.adc.adc_constants import (
     DiffMode,
     RTDModes,
     ADC1PGA,
+    AnalogIn,
 )
 from edgepi.adc.edgepi_adc import EdgePiADC
+
+from edgepi.dac.edgepi_dac import EdgePiDAC
+from edgepi.dac.dac_constants import DACChannel
 
 _logger = logging.getLogger(__name__)
 
@@ -791,7 +797,6 @@ def test_voltage_individual(ch, adc):
     _logger.info(f"test_voltage_individual: voltage  = {out}")
     assert out != 0
 
-
 @pytest.mark.parametrize(
     "adc_num, ch",
     [
@@ -834,7 +839,6 @@ def test_voltage_continuous(adc_num, ch, adc):
     finally:
         adc.stop_conversions(adc_num)
 
-
 @pytest.mark.parametrize('adc_num, diff, mux_reg, mux_reg_val',
     [
         (ADCNum.ADC_1, DiffMode.DIFF_1, ADCReg.REG_INPMUX, 0x01),
@@ -865,3 +869,70 @@ def test_set_rtd(enable, rtd_mode, adc_num, expected, adc):
     adc.set_rtd(set_rtd=enable, adc_num=adc_num)
     assert adc.get_state().rtd_mode == rtd_mode
     assert adc.get_state().rtd_adc == expected
+
+@pytest.mark.parametrize(
+    "out_list, channel_list, voltage",
+    [
+        ([DACChannel.AOUT2], [AnalogIn.AIN2], 3.0),
+        ([DACChannel.AOUT3], [AnalogIn.AIN3], 2.0),
+        ([DACChannel.AOUT2, DACChannel.AOUT3], [AnalogIn.AIN2, AnalogIn.AIN3], 1.0),
+    ],
+)
+def test_adc_batch_voltage(out_list, channel_list, voltage, adc):
+    edgepi_dac = EdgePiDAC()
+    edgepi_dac.set_dac_gain(False)
+
+    # write voltage values
+    for out_channel in out_list:
+        edgepi_dac.write_voltage(out_channel, voltage)
+
+    # sample
+    result_list = []
+    for i in range(250):
+        result_list += adc.adc1_config_and_read_samples_batch(
+            data_rate=ADC1DataRate.SPS_38400,
+            analog_in_list=channel_list,
+        )
+
+    for i, _ in enumerate(channel_list):
+        avg = statistics.mean(result_list[i::len(channel_list)])
+        assert (voltage - 0.1) <= avg <= (voltage + 0.1)
+
+    edgepi_dac.reset()
+    adc.reset()
+
+@pytest.mark.parametrize(
+    "channel_list",
+    [
+        ([
+            AnalogIn.AIN2, AnalogIn.AIN3,
+        ]),
+        ([
+            AnalogIn.AIN1, AnalogIn.AIN2, AnalogIn.AIN3, AnalogIn.AIN4,
+            AnalogIn.AIN5, AnalogIn.AIN6, AnalogIn.AIN7, AnalogIn.AIN8,
+        ]),
+    ],
+)
+def test_adc_batch_speed(channel_list, adc):
+    '''
+    This is a speed test, making sure that all ADC inputs can be read at a rate of 100hz (10ms)
+    '''
+    AVG_SPEED_TARGET_MS = 10
+    NUM_ITER = 500
+
+    start = time.time()
+
+    # do samples
+    result_list = []
+    for _ in range(NUM_ITER):
+        result_list += adc.adc1_config_and_read_samples_batch(
+            data_rate=ADC1DataRate.SPS_38400,
+            analog_in_list=channel_list,
+        )
+
+    avg = 1000.0 * ((time.time() - start) / NUM_ITER)
+    # print(avg)
+    assert avg <= AVG_SPEED_TARGET_MS
+
+    # reset adc registers to pre-test values
+    adc.reset()

--- a/src/test_edgepi/integration_tests/test_adc/test_adc.py
+++ b/src/test_edgepi/integration_tests/test_adc/test_adc.py
@@ -881,7 +881,7 @@ def test_set_rtd(enable, rtd_mode, adc_num, expected, adc):
 def test_adc_batch_voltage(out_list, channel_list, voltage, adc):
     edgepi_dac = EdgePiDAC()
     edgepi_dac.set_dac_gain(False)
-
+    
     # write voltage values
     for out_channel in out_list:
         edgepi_dac.write_voltage(out_channel, voltage)

--- a/src/test_edgepi/integration_tests/test_adc/test_adc.py
+++ b/src/test_edgepi/integration_tests/test_adc/test_adc.py
@@ -896,7 +896,7 @@ def test_adc_batch_voltage(out_list, channel_list, voltage, adc):
 
     for i, _ in enumerate(channel_list):
         avg = statistics.mean(result_list[i::len(channel_list)])
-        assert (voltage - 0.1) <= avg <= (voltage + 0.1)
+        assert (voltage - 0.15) <= avg <= (voltage + 0.15)
 
     edgepi_dac.reset()
     adc.reset()

--- a/src/test_edgepi/integration_tests/test_digital_in/test_digital_in.py
+++ b/src/test_edgepi/integration_tests/test_digital_in/test_digital_in.py
@@ -1,6 +1,8 @@
 '''Integration tests for edgepi_digital_input.py module'''
 
+import time
 import pytest
+
 from edgepi.digital_input.edgepi_digital_input import EdgePiDigitalInput
 from edgepi.digital_input.digital_input_constants import DinPins
 
@@ -15,6 +17,28 @@ from edgepi.digital_input.digital_input_constants import DinPins
     (DinPins.DIN8),
 ])
 def test_input_state(pin_name):
-    din=EdgePiDigitalInput()
+    din = EdgePiDigitalInput()
     pin_state = din.digital_input_state(pin_name)
     assert pin_state is False
+
+@pytest.mark.parametrize("pin_names", [
+    ([
+        DinPins.DIN1, DinPins.DIN2, DinPins.DIN3, DinPins.DIN4, 
+        DinPins.DIN5, DinPins.DIN6, DinPins.DIN7, DinPins.DIN8
+    ]),
+])
+def test_input_state_speed(pin_names):
+    TARGET_MS = 1
+    
+    din = EdgePiDigitalInput()
+    
+    start = time.time()
+    
+    pin_states = []
+    for i in range(500):
+        tmp = din.digital_input_state_batch(pin_names)
+        pin_states += tmp
+        
+    avg = 1000.0 * (time.time() - start) / 500
+    #print(avg)
+    assert avg < TARGET_MS

--- a/src/test_edgepi/integration_tests/test_digital_in/test_digital_in.py
+++ b/src/test_edgepi/integration_tests/test_digital_in/test_digital_in.py
@@ -35,7 +35,7 @@ def test_input_state_speed(pin_names):
     start = time.time()
     
     pin_states = []
-    for i in range(500):
+    for _ in range(500):
         tmp = din.digital_input_state_batch(pin_names)
         pin_states += tmp
         

--- a/src/test_edgepi/integration_tests/test_eeprom/test_eeprom.py
+++ b/src/test_edgepi/integration_tests/test_eeprom/test_eeprom.py
@@ -10,6 +10,7 @@ PATH = os.path.dirname(os.path.abspath(__file__))
 import string
 import random
 import base64
+import platform
 
 import time
 import logging
@@ -54,7 +55,7 @@ def test__page_write_register(data, address, eeprom):
         for indx, init_data in enumerate(initial_data):
             assert init_data != new_data[indx]
             assert new_data[indx] == data[indx]
-            
+
     finally:
         # Write the original data back
         eeprom.write_edgepi_data(original_data)

--- a/src/test_edgepi/unit_tests/test_adc/test_adc_multiplexers.py
+++ b/src/test_edgepi/unit_tests/test_adc/test_adc_multiplexers.py
@@ -14,7 +14,7 @@ from edgepi.adc.adc_multiplexers import (
 
 
 @pytest.mark.parametrize(
-    "adc1_reg, adc1_mux, adc2_reg, adc2_mux, expected",
+    "adc1_mux, adc2_mux, expected",
     [
         (
             (None, None), (None, None),

--- a/src/test_edgepi/unit_tests/test_adc/test_adc_multiplexers.py
+++ b/src/test_edgepi/unit_tests/test_adc/test_adc_multiplexers.py
@@ -14,7 +14,7 @@ from edgepi.adc.adc_multiplexers import (
 
 
 @pytest.mark.parametrize(
-    "mux_updates, expected",
+    "adc1_reg, adc1_mux, adc2_reg, adc2_mux, expected",
     [
         (
             ADCReg.REG_INPMUX, (None, None), ADCReg.REG_ADC2MUX, (None, None),

--- a/src/test_edgepi/unit_tests/test_adc/test_adc_multiplexers.py
+++ b/src/test_edgepi/unit_tests/test_adc/test_adc_multiplexers.py
@@ -17,51 +17,51 @@ from edgepi.adc.adc_multiplexers import (
     "adc1_reg, adc1_mux, adc2_reg, adc2_mux, expected",
     [
         (
-            ADCReg.REG_INPMUX, (None, None), ADCReg.REG_ADC2MUX, (None, None),
+            (None, None), (None, None),
             [],
         ),
         (
-            ADCReg.REG_INPMUX, (None, CH.AIN2), ADCReg.REG_ADC2MUX, (None, None),
+            (None, CH.AIN2), (None, None),
             [],
         ),
         (
-            ADCReg.REG_INPMUX, (CH.AIN1, CH.AINCOM), ADCReg.REG_ADC2MUX, (None, None),
+            (CH.AIN1, CH.AINCOM), (None, None),
             [OpCode(0x1A, ADCReg.REG_INPMUX.value, BitMask.BYTE.value)],
         ),
         (
-            ADCReg.REG_INPMUX, (CH.AIN7, None), ADCReg.REG_ADC2MUX, (None, None),
+            (CH.AIN7, None), (None, None),
             [],
         ),
         (
-            ADCReg.REG_INPMUX, (None, CH.AIN5), ADCReg.REG_ADC2MUX, (None, None),
+            (None, CH.AIN5), (None, None),
             [],
         ),
         (
-            ADCReg.REG_INPMUX, (None, None), ADCReg.REG_ADC2MUX, (CH.AIN5, None),
+            (None, None), (CH.AIN5, None),
             [],
         ),
         (
-            ADCReg.REG_INPMUX, (None, None), ADCReg.REG_ADC2MUX, (None, CH.AIN6),
+            (None, None), (None, CH.AIN6),
             [],
         ),
         (
-            ADCReg.REG_INPMUX, (None, None), ADCReg.REG_ADC2MUX, (CH.AIN5, CH.AIN6),
+            (None, None), (CH.AIN5, CH.AIN6),
             [OpCode(0x56, ADCReg.REG_ADC2MUX.value, BitMask.BYTE.value)],
         ),
         (
-            ADCReg.REG_INPMUX, (CH.AIN1, None), ADCReg.REG_ADC2MUX, (None, None),
+            (CH.AIN1, None), (None, None),
             [],
         ),
         (
-            ADCReg.REG_INPMUX, (CH.AIN5, None), ADCReg.REG_ADC2MUX, (None, CH.AIN6),
+            (CH.AIN5, None), (None, CH.AIN6),
             [],
         ),
         (
-            ADCReg.REG_INPMUX, (None, CH.AIN5), ADCReg.REG_ADC2MUX, (CH.AIN6, None),
+            (None, CH.AIN5), (CH.AIN6, None),
             [],
         ),
         (
-            ADCReg.REG_INPMUX, (CH.AIN1, CH.AIN2), ADCReg.REG_ADC2MUX, (CH.AIN3, CH.AIN4),
+            (CH.AIN1, CH.AIN2), (CH.AIN3, CH.AIN4),
             [
                 OpCode(0x12, ADCReg.REG_INPMUX.value, BitMask.BYTE.value),
                 OpCode(0x34, ADCReg.REG_ADC2MUX.value, BitMask.BYTE.value),
@@ -69,8 +69,8 @@ from edgepi.adc.adc_multiplexers import (
         ),
     ],
 )
-def test_generate_mux_opcodes(adc1_reg, adc1_mux, adc2_reg, adc2_mux, expected):
-    assert generate_mux_opcodes(adc1_reg, adc1_mux, adc2_reg, adc2_mux) == expected
+def test_generate_mux_opcodes(adc1_mux, adc2_mux, expected):
+    assert generate_mux_opcodes(adc1_mux, adc2_mux) == expected
 
 
 @pytest.mark.parametrize(

--- a/src/test_edgepi/unit_tests/test_adc/test_adc_multiplexers.py
+++ b/src/test_edgepi/unit_tests/test_adc/test_adc_multiplexers.py
@@ -17,87 +17,51 @@ from edgepi.adc.adc_multiplexers import (
     "mux_updates, expected",
     [
         (
-            {
-                ADCReg.REG_INPMUX: (None, None),
-                ADCReg.REG_ADC2MUX: (None, None),
-            },
+            ADCReg.REG_INPMUX, (None, None), ADCReg.REG_ADC2MUX, (None, None),
             [],
         ),
         (
-            {
-                ADCReg.REG_INPMUX: (None, CH.AIN2),
-                ADCReg.REG_ADC2MUX: (None, None),
-            },
+            ADCReg.REG_INPMUX, (None, CH.AIN2), ADCReg.REG_ADC2MUX, (None, None),
             [],
         ),
         (
-            {
-                ADCReg.REG_INPMUX: (CH.AIN1, CH.AINCOM),
-                ADCReg.REG_ADC2MUX: (None, None),
-            },
+            ADCReg.REG_INPMUX, (CH.AIN1, CH.AINCOM), ADCReg.REG_ADC2MUX, (None, None),
             [OpCode(0x1A, ADCReg.REG_INPMUX.value, BitMask.BYTE.value)],
         ),
         (
-            {
-                ADCReg.REG_INPMUX: (CH.AIN7, None),
-                ADCReg.REG_ADC2MUX: (None, None),
-            },
+            ADCReg.REG_INPMUX, (CH.AIN7, None), ADCReg.REG_ADC2MUX, (None, None),
             [],
         ),
         (
-            {
-                ADCReg.REG_INPMUX: (None, CH.AIN5),
-                ADCReg.REG_ADC2MUX: (None, None),
-            },
+            ADCReg.REG_INPMUX, (None, CH.AIN5), ADCReg.REG_ADC2MUX, (None, None),
             [],
         ),
         (
-            {
-                ADCReg.REG_INPMUX: (None, None),
-                ADCReg.REG_ADC2MUX: (CH.AIN5, None),
-            },
+            ADCReg.REG_INPMUX, (None, None), ADCReg.REG_ADC2MUX, (CH.AIN5, None),
             [],
         ),
         (
-            {
-                ADCReg.REG_INPMUX: (None, None),
-                ADCReg.REG_ADC2MUX: (None, CH.AIN6),
-            },
+            ADCReg.REG_INPMUX, (None, None), ADCReg.REG_ADC2MUX, (None, CH.AIN6),
             [],
         ),
         (
-            {
-                ADCReg.REG_INPMUX: (None, None),
-                ADCReg.REG_ADC2MUX: (CH.AIN5, CH.AIN6),
-            },
+            ADCReg.REG_INPMUX, (None, None), ADCReg.REG_ADC2MUX, (CH.AIN5, CH.AIN6),
             [OpCode(0x56, ADCReg.REG_ADC2MUX.value, BitMask.BYTE.value)],
         ),
         (
-            {
-                ADCReg.REG_INPMUX: (CH.AIN1, None),
-                ADCReg.REG_ADC2MUX: (None, None),
-            },
+            ADCReg.REG_INPMUX, (CH.AIN1, None), ADCReg.REG_ADC2MUX, (None, None),
             [],
         ),
         (
-            {
-                ADCReg.REG_INPMUX: (CH.AIN5, None),
-                ADCReg.REG_ADC2MUX: (None, CH.AIN6),
-            },
+            ADCReg.REG_INPMUX, (CH.AIN5, None), ADCReg.REG_ADC2MUX, (None, CH.AIN6),
             [],
         ),
         (
-            {
-                ADCReg.REG_INPMUX: (None, CH.AIN5),
-                ADCReg.REG_ADC2MUX: (CH.AIN6, None),
-            },
+            ADCReg.REG_INPMUX, (None, CH.AIN5), ADCReg.REG_ADC2MUX, (CH.AIN6, None),
             [],
         ),
         (
-            {
-                ADCReg.REG_INPMUX: (CH.AIN1, CH.AIN2),
-                ADCReg.REG_ADC2MUX: (CH.AIN3, CH.AIN4),
-            },
+            ADCReg.REG_INPMUX, (CH.AIN1, CH.AIN2), ADCReg.REG_ADC2MUX, (CH.AIN3, CH.AIN4),
             [
                 OpCode(0x12, ADCReg.REG_INPMUX.value, BitMask.BYTE.value),
                 OpCode(0x34, ADCReg.REG_ADC2MUX.value, BitMask.BYTE.value),
@@ -105,8 +69,8 @@ from edgepi.adc.adc_multiplexers import (
         ),
     ],
 )
-def test_generate_mux_opcodes(mux_updates, expected):
-    assert generate_mux_opcodes(mux_updates) == expected
+def test_generate_mux_opcodes(adc1_reg, adc1_mux, adc2_reg, adc2_mux, expected):
+    assert generate_mux_opcodes(adc1_reg, adc1_mux, adc2_reg, adc2_mux) == expected
 
 
 @pytest.mark.parametrize(

--- a/src/test_edgepi/unit_tests/test_adc/test_adc_voltage.py
+++ b/src/test_edgepi/unit_tests/test_adc/test_adc_voltage.py
@@ -3,7 +3,6 @@
 import pytest
 
 from edgepi.calibration.calibration_constants import CalibParam
-from edgepi.utilities.utilities import bitstring_from_list
 from edgepi.adc.adc_constants import ADCNum
 from edgepi.adc.adc_voltage import (
     _code_to_input_voltage,

--- a/src/test_edgepi/unit_tests/test_adc/test_adc_voltage.py
+++ b/src/test_edgepi/unit_tests/test_adc/test_adc_voltage.py
@@ -26,8 +26,7 @@ OFFSET = 0
                          ([0x7F,0xFF,0xFF,0xFF], False),
                         ])
 def test_is_negative_voltage(code, result):
-    code_bits = bitstring_from_list(code)
-    assert _is_negative_voltage(code_bits) ==result
+    assert _is_negative_voltage(code) == result
 
 
 @pytest.mark.parametrize(

--- a/src/test_edgepi/unit_tests/test_din/test_edgepi_din.py
+++ b/src/test_edgepi/unit_tests/test_din/test_edgepi_din.py
@@ -38,9 +38,33 @@ def fixture_test_dac(mocker):
                          (GpioPins.DOUT2, False, False, pytest.raises(InvalidPinName)),
                          (None, False, False, pytest.raises(InvalidPinName))])
 def test_edgepi_digital_input_state(mocker, pin_name, mock_value, result, error, din):
-    mocker.patch("edgepi.gpio.edgepi_gpio.EdgePiGPIOChip.read_gpio_pin_state",
+    mocker.patch("edgepi.gpio.edgepi_gpio.EdgePiGPIOChip.fast_read_din_state",
                  return_value = mock_value)
     with error:
         state = din.digital_input_state(pin_name)
         assert state == result
-    
+
+@pytest.mark.parametrize(
+    "pin_names, mock_values, error",
+    [
+        ([DinPins.DIN1], [True], does_not_raise()),
+        ([DinPins.DIN2], [True], does_not_raise()),
+        ([DinPins.DIN3, DinPins.DIN4, DinPins.DIN5], [True, False, True], does_not_raise()),
+        ([DinPins.DIN1, DinPins.DIN6, DinPins.DIN7, DinPins.DIN8], [True, True, True, True], does_not_raise()),
+        ([DinPins.DIN1, DinPins.DIN2, DinPins.DIN3, DinPins.DIN4, DinPins.DIN5, DinPins.DIN6, DinPins.DIN7, DinPins.DIN8], [True, True, True, True, True, False, True, False], does_not_raise()),
+        ([DinPins.DIN2, DinPins.DIN2, DinPins.DIN2], [False, False, False], does_not_raise()),
+        ([], [], pytest.raises(ValueError)),
+        (None, [], pytest.raises(ValueError)),
+        ([GpioPins.DOUT2], [], pytest.raises(InvalidPinName)),
+        ([DinPins.DIN2, GpioPins.DOUT2], [False], pytest.raises(InvalidPinName)),
+        ([DinPins.DIN2, None, DinPins.DIN3], [False, False], pytest.raises(InvalidPinName)),
+    ]
+)
+def test_edgepi_digital_input_state_batch(mocker, pin_names, mock_values, error, din):
+    mocker.patch(
+        "edgepi.gpio.edgepi_gpio.EdgePiGPIOChip.fast_read_din_state_batch",
+        return_value = mock_values
+    )
+    with error:
+        state_list = din.digital_input_state_batch(pin_names)
+        assert state_list == mock_values


### PR DESCRIPTION
The goal of this PR was to improve the performance of the SDK's ADC reads to be higher than 100hz. All 8 ADC inputs can consistently be read in less than 10ms on average (with a somewhat surprisingly high variance, likely due to the OS), while all 8 digital inputs can be read in less than 1ms on average.

It's possible to improve the performance more than 100 hz for all 8 ADC, however 1/3 of all time is being spend sleeping, while another 1/3 is spent transferring data over SPI. I think it's unlikely to get faster than 200 hz.

The speed improvements are due to bit optimizations, minimizing data sent over the channel, python optimizations, and batching of requests (minimize system calls opening & closing devices), all of which were found via profiling. For more info, see [this (private) page in the wiki](https://wiki.edgepi.com/en/prv/wip/gabe/high-freq-read-testing).