### PR TITLE
Improve performance of ADC reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ The **Performance** column represents how long it takes to call one function, wh
 | Single DIN | 0.85ms per 8 DIN | 1171 Hz | `digital_input_state(...)` | [examples/single_din.py](https://github.com/EdgePi-Cloud/edgepi-python-sdk/tree/main/examples/single_din.py) | |
 | Batched DIN | 0.52ms per 8 DIN | 1936 Hz | `digital_input_state_batch(...)` | [examples/batched_din.py](https://github.com/EdgePi-Cloud/edgepi-python-sdk/tree/main/examples/batched_din.py) | |
 | Single ADC | 97.3 ms per 8 ADC | 10.3 Hz | `set_config(...)` <br><br> `single_sample()` | [examples/single_adc.py](https://github.com/EdgePi-Cloud/edgepi-python-sdk/tree/main/examples/single_adc.py) | Reads from ADC1 only |
-| Batched ADC | 6.49 ms per 8 ADC | 154 Hz | `batch_read_samples_adc1(...)` | [examples/batched_adc.py](https://github.com/EdgePi-Cloud/edgepi-python-sdk/tree/main/examples/batched_adc.py) | Reads from ADC1 only |
-| Batched ADC/Diff | 5.467 ms per 4 ADC, 2 Diff | 183 Hz | `batch_read_samples_adc1(...)` | [examples/batched_adc_diff.py](https://github.com/EdgePi-Cloud/edgepi-python-sdk/tree/main/examples/batched_adc_diff.py) | Differential ADC inputs each use two pins. Reads from ADC1 only |
+| Batched ADC | 6.49 ms per 8 ADC | 154 Hz | `read_samples_adc1_batch(...)` | [examples/batched_adc.py](https://github.com/EdgePi-Cloud/edgepi-python-sdk/tree/main/examples/batched_adc.py) | Reads from ADC1 only |
+| Batched ADC/Diff | 5.467 ms per 4 ADC, 2 Diff | 183 Hz | `read_samples_adc1_batch(...)` | [examples/batched_adc_diff.py](https://github.com/EdgePi-Cloud/edgepi-python-sdk/tree/main/examples/batched_adc_diff.py) | Differential ADC inputs each use two pins. Reads from ADC1 only |
 | Thermocouple (TC) | 100.2ms | 9.98 hz | `read_temperatures()` | [examples/single_tc.py](https://github.com/EdgePi-Cloud/edgepi-python-sdk/tree/main/examples/single_tc.py) | Limited by [hardware](https://www.analog.com/media/en/technical-documentation/data-sheets/MAX31856.pdf) (see conversion mode). 100ms is needed for accurate (19 bit) readings |
 
 # Bug Reports / Feature Requests

--- a/README.md
+++ b/README.md
@@ -109,15 +109,18 @@ Make sure to include the `pypi-` prefix for your token value.
 
 # Performance
 
-The following benchmarks were measured on the Rasberry Pi 4, with all edgepi daemons disabled.
+The following benchmarks were measured on the Rasberry Pi 4, with all edgepi daemons disabled. They're also the slowest average of 3 runs.
 
 The **Performance** column represents how long it takes to call one function, while the **Max Read Frequency** column represents how many times that function could be called every second.
 
-| Feature | Performance | Max Read Frequency | Function | Example | Desc |
+| Feature | Performance | Max Read Frequency | Function | Example | Description |
 | -- | -- | -- | -- | -- | -- |
-| Single DIN | 0.85ms per 8 DIN | 1171 Hz | `digital_input_state(pin)` | [examples/single_din.py](https://github.com/EdgePi-Cloud/edgepi-python-sdk/tree/main/examples/single_din.py) | |
-| Batched DIN | 0.52ms per 8 DIN | 1936 Hz | `digital_input_state_batch(pin_list)` | [examples/batched_din.py](https://github.com/EdgePi-Cloud/edgepi-python-sdk/tree/main/examples/batched_din.py) | |
-| Thermocouple (TC) | 100.2ms | 9.98 hz | `read_temperatures()` | [examples/single_tc.py](https://github.com/EdgePi-Cloud/edgepi-python-sdk/tree/main/examples/single_tc.py) | Limited by [hardware](https://www.analog.com/media/en/technical-documentation/data-sheets/MAX31856.pdf) (see conversion mode). 100ms is needed to get accurate (19 bit) readings |
+| Single DIN | 0.85ms per 8 DIN | 1171 Hz | `digital_input_state(...)` | [examples/single_din.py](https://github.com/EdgePi-Cloud/edgepi-python-sdk/tree/main/examples/single_din.py) | |
+| Batched DIN | 0.52ms per 8 DIN | 1936 Hz | `digital_input_state_batch(...)` | [examples/batched_din.py](https://github.com/EdgePi-Cloud/edgepi-python-sdk/tree/main/examples/batched_din.py) | |
+| Single ADC | 97.3 ms per 8 ADC | 10.3 Hz | `set_config(...)` <br><br> `single_sample()` | [examples/single_adc.py](https://github.com/EdgePi-Cloud/edgepi-python-sdk/tree/main/examples/single_adc.py) | Reads from ADC1 only |
+| Batched ADC | 6.49 ms per 8 ADC | 154 Hz | `batch_read_samples_adc1(...)` | [examples/batched_adc.py](https://github.com/EdgePi-Cloud/edgepi-python-sdk/tree/main/examples/batched_adc.py) | Reads from ADC1 only |
+| Batched ADC/Diff | 5.467 ms per 4 ADC, 2 Diff | 183 Hz | `batch_read_samples_adc1(...)` | [examples/batched_adc_diff.py](https://github.com/EdgePi-Cloud/edgepi-python-sdk/tree/main/examples/batched_adc_diff.py) | Differential ADC inputs each use two pins. Reads from ADC1 only |
+| Thermocouple (TC) | 100.2ms | 9.98 hz | `read_temperatures()` | [examples/single_tc.py](https://github.com/EdgePi-Cloud/edgepi-python-sdk/tree/main/examples/single_tc.py) | Limited by [hardware](https://www.analog.com/media/en/technical-documentation/data-sheets/MAX31856.pdf) (see conversion mode). 100ms is needed for accurate (19 bit) readings |
 
 # Bug Reports / Feature Requests
 Use [GitHub Issues Page](https://github.com/EdgePi-Cloud/edgepi-python-sdk/issues) to report any issues or feature requests.

--- a/examples/batched_adc.py
+++ b/examples/batched_adc.py
@@ -1,0 +1,35 @@
+import time
+
+from edgepi.adc.edgepi_adc import EdgePiADC
+from edgepi.adc.adc_constants import AnalogIn, ConvMode, ADCNum, ADC1DataRate, DiffMode
+
+from edgepi.dac.edgepi_dac import EdgePiDAC
+from edgepi.dac.dac_constants import DACChannel as Ch
+
+ITER = 50
+
+def run_test():
+    edgepi_adc = EdgePiADC(enable_cache=False)
+
+    start = time.time()
+    result_list = []
+    adc_choices = [
+        AnalogIn.AIN1, AnalogIn.AIN2, AnalogIn.AIN3, AnalogIn.AIN4,
+        AnalogIn.AIN5, AnalogIn.AIN6, AnalogIn.AIN7, AnalogIn.AIN8,
+    ]
+
+    for _ in range(ITER):
+        tmp = edgepi_adc.batch_config_and_read_samples_adc1(
+            data_rate=ADC1DataRate.SPS_38400,
+            analog_in_list=adc_choices,
+        )
+        result_list += [tmp]
+
+    elapsed = time.time() - start
+
+    print(result_list[24])
+    print(f"Time elapsed {elapsed/ITER:.6f} s")
+    print(f"Frequency {ITER/elapsed:.4f} hz")
+
+if __name__ == "__main__":
+    run_test()

--- a/examples/batched_adc.py
+++ b/examples/batched_adc.py
@@ -22,7 +22,7 @@ def run_test():
     ]
 
     for _ in range(ITER):
-        tmp = edgepi_adc.batch_read_samples_adc1(
+        tmp = edgepi_adc.read_samples_adc1_batch(
             data_rate=ADC1DataRate.SPS_38400,
             analog_in_list=adc_choices,
         )

--- a/examples/batched_adc_diff.py
+++ b/examples/batched_adc_diff.py
@@ -1,30 +1,36 @@
-"""Example reading from ADC using the batched function"""
+"""Example reading from from individual ADC pins"""
 
 import time
 
 from edgepi.adc.edgepi_adc import EdgePiADC
-from edgepi.adc.adc_constants import AnalogIn, ADC1DataRate
+from edgepi.adc.adc_constants import AnalogIn, ADC1DataRate, DiffMode
 
 ITER = 50
 
 def run_test():
     """
-    This test performs 400 Analog input reads, batched 8 reads at a time.
+    This test performs 300 analog input reads, with 50 for each of 4 analog pins, and
+    50 for each of 2 differential analog pairs.
     """
-
+    
     edgepi_adc = EdgePiADC(enable_cache=False)
 
     start = time.time()
     result_list = []
     adc_choices = [
-        AnalogIn.AIN1, AnalogIn.AIN2, AnalogIn.AIN3, AnalogIn.AIN4,
-        AnalogIn.AIN5, AnalogIn.AIN6, AnalogIn.AIN7, AnalogIn.AIN8,
+        AnalogIn.AIN1, AnalogIn.AIN2,
+        AnalogIn.AIN5, AnalogIn.AIN6,
+    ]
+    differential_pairs = [
+        DiffMode.DIFF_2,
+        DiffMode.DIFF_4,
     ]
 
     for _ in range(ITER):
         tmp = edgepi_adc.batch_read_samples_adc1(
-            data_rate=ADC1DataRate.SPS_38400,
-            analog_in_list=adc_choices,
+            ADC1DataRate.SPS_38400,
+            adc_choices,
+            differential_pairs,
         )
         result_list += [tmp]
 

--- a/examples/batched_adc_diff.py
+++ b/examples/batched_adc_diff.py
@@ -27,7 +27,7 @@ def run_test():
     ]
 
     for _ in range(ITER):
-        tmp = edgepi_adc.batch_read_samples_adc1(
+        tmp = edgepi_adc.read_samples_adc1_batch(
             ADC1DataRate.SPS_38400,
             adc_choices,
             differential_pairs,

--- a/examples/batched_adc_diff.py
+++ b/examples/batched_adc_diff.py
@@ -12,7 +12,7 @@ def run_test():
     This test performs 300 analog input reads, with 50 for each of 4 analog pins, and
     50 for each of 2 differential analog pairs.
     """
-    
+
     edgepi_adc = EdgePiADC(enable_cache=False)
 
     start = time.time()

--- a/examples/single_adc.py
+++ b/examples/single_adc.py
@@ -1,17 +1,16 @@
-"""Example reading from ADC using the batched function"""
+"""Example reading from individual ADC pins"""
 
 import time
 
 from edgepi.adc.edgepi_adc import EdgePiADC
-from edgepi.adc.adc_constants import AnalogIn, ADC1DataRate
+from edgepi.adc.adc_constants import AnalogIn, ADC1DataRate, ConvMode
 
 ITER = 50
 
 def run_test():
     """
-    This test performs 400 Analog input reads, batched 8 reads at a time.
+    This test performs 400 analog input reads, with a total of 50 per ADC pin.
     """
-
     edgepi_adc = EdgePiADC(enable_cache=False)
 
     start = time.time()
@@ -22,11 +21,18 @@ def run_test():
     ]
 
     for _ in range(ITER):
-        tmp = edgepi_adc.batch_read_samples_adc1(
-            data_rate=ADC1DataRate.SPS_38400,
-            analog_in_list=adc_choices,
-        )
-        result_list += [tmp]
+        tmp_list = []
+        for ain in adc_choices:
+            edgepi_adc.set_config(
+                adc_1_analog_in=ain,
+                conversion_mode=ConvMode.PULSE,
+                adc_1_data_rate=ADC1DataRate.SPS_38400
+            )
+
+            voltage = edgepi_adc.single_sample()
+            tmp_list += [voltage]
+
+        result_list += [tmp_list]
 
     elapsed = time.time() - start
 

--- a/src/edgepi/adc/adc_commands.py
+++ b/src/edgepi/adc/adc_commands.py
@@ -77,7 +77,7 @@ class ADCCommands:
         """Command to reset ADC"""
         _logger.debug("Command to send is %s", ([ADCComs.COM_RESET.value]))
         return [ADCComs.COM_RESET.value]
-    
+
     @staticmethod
     def read_command_tuple(
         mode2_register_value: Optional[int],

--- a/src/edgepi/adc/adc_commands.py
+++ b/src/edgepi/adc/adc_commands.py
@@ -48,6 +48,9 @@ class ADCCommands:
         Returns the command to read from the ADC, after waiting the required time for
         conversions to take effect
         """
+        # Since this is full duplex SPI, we have to write something every time we expect
+        # to read something as well, so we add the 6 0xff bytes so that periphery will read
+        # the 6 results bytes we care about.
         return [adc_num.read_cmd] + [255] * ADC_VOLTAGE_READ_LEN
 
     def stop_adc(self, adc_num: ADCReadInfo):

--- a/src/edgepi/adc/adc_commands.py
+++ b/src/edgepi/adc/adc_commands.py
@@ -30,6 +30,11 @@ class ADCCommands:
         command = [ADCComs.COM_WREG.value + address, len(values) - 1]
         return command + values
 
+    def unsafe_write_register_command(self, address, values):
+        """Trigger ADC register write - unsafe removes all checks"""
+        command = [ADCComs.COM_WREG.value + address, len(values) - 1]
+        return command + values
+
     def start_adc(self, adc_num: ADCNum):
         """Command to start ADC"""
         _logger.debug("Command to send is %s", ([adc_num.start_cmd]))

--- a/src/edgepi/adc/adc_commands.py
+++ b/src/edgepi/adc/adc_commands.py
@@ -3,8 +3,11 @@
 
 import logging
 
-from edgepi.adc.adc_constants import ADCComs, ADCNum
-
+from edgepi.adc.adc_constants import (
+    ADCComs,
+    ADCReadInfo,
+    ADC_VOLTAGE_READ_LEN,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -35,17 +38,22 @@ class ADCCommands:
         command = [ADCComs.COM_WREG.value + address, len(values) - 1]
         return command + values
 
-    def start_adc(self, adc_num: ADCNum):
-        """Command to start ADC"""
+    def start_adc(self, adc_num: ADCReadInfo):
+        """Command to start ADC conversions"""
         _logger.debug("Command to send is %s", ([adc_num.start_cmd]))
         return [adc_num.start_cmd]
 
+    def read_adc(self, adc_num: ADCReadInfo):
+        """
+        Returns the command to read from the ADC, after waiting the required time for
+        conversions to take effect
+        """
+        return [adc_num.read_cmd] + [255] * ADC_VOLTAGE_READ_LEN
 
-    def stop_adc(self, adc_num: ADCNum):
+    def stop_adc(self, adc_num: ADCReadInfo):
         """Command to stop ADC"""
         _logger.debug("Command to send is %s", ([adc_num.stop_cmd]))
         return [adc_num.stop_cmd]
-
 
     def reset_adc(self):
         """Command to reset ADC"""

--- a/src/edgepi/adc/adc_commands.py
+++ b/src/edgepi/adc/adc_commands.py
@@ -1,13 +1,18 @@
 """ Utility module for ADC commands """
 
-
 import logging
+from typing import Optional
 
 from edgepi.adc.adc_constants import (
     ADCComs,
+    ADCChannel as CH,
+    ADCNum,
+    ADCReg,
     ADCReadInfo,
     ADC_VOLTAGE_READ_LEN,
+
 )
+from edgepi.adc.adc_multiplexers import generate_mux_opcode
 
 _logger = logging.getLogger(__name__)
 
@@ -33,7 +38,8 @@ class ADCCommands:
         command = [ADCComs.COM_WREG.value + address, len(values) - 1]
         return command + values
 
-    def unsafe_write_register_command(self, address: int, values: list[int]):
+    @staticmethod
+    def unsafe_write_register_command(address: int, values: list[int]):
         """
         Trigger ADC register write - unsafe removes all arguments validation. 
 
@@ -43,12 +49,14 @@ class ADCCommands:
         command = [ADCComs.COM_WREG.value + address, len(values) - 1]
         return command + values
 
-    def start_adc_command(self, adc_num: ADCReadInfo):
+    @staticmethod
+    def start_adc_command(adc_num: ADCReadInfo):
         """Command to start ADC conversions"""
         _logger.debug("Command to send is %s", ([adc_num.start_cmd]))
         return [adc_num.start_cmd]
 
-    def read_adc_command(self, adc_num: ADCReadInfo):
+    @staticmethod
+    def read_adc_command(adc_num: ADCReadInfo, num_bytes: int):
         """
         Returns the command to read from the ADC, after waiting the required time for
         conversions to take effect
@@ -56,17 +64,52 @@ class ADCCommands:
         # Since this is full duplex SPI, we have to write something every time we expect
         # to read something as well, so we add the 6 0xff bytes so that periphery will read
         # the 6 results bytes we care about.
-        return [adc_num.read_cmd] + [255] * ADC_VOLTAGE_READ_LEN
+        return [adc_num.read_cmd] + [255] * num_bytes
 
-    def stop_adc_command(self, adc_num: ADCReadInfo):
+    @staticmethod
+    def stop_adc_command(adc_num: ADCReadInfo):
         """Command to stop ADC"""
         _logger.debug("Command to send is %s", ([adc_num.stop_cmd]))
         return [adc_num.stop_cmd]
 
-    def reset_adc_command(self):
+    @staticmethod
+    def reset_adc_command():
         """Command to reset ADC"""
         _logger.debug("Command to send is %s", ([ADCComs.COM_RESET.value]))
         return [ADCComs.COM_RESET.value]
+    
+    @staticmethod
+    def read_command_tuple(
+        mode2_register_value: Optional[int],
+        conversion_delay: float,
+        mux_p: CH,
+        mux_n: CH,
+    ) -> tuple[list, float, list]:
+        """
+        Returns a tuple containing two spi commands, separated by a delay. For use
+        with spi_apply_adc_commands
+        """
+        inpmux_register_value = generate_mux_opcode(ADCReg.REG_INPMUX, mux_p, mux_n).op_code
+        if mode2_register_value is not None:
+            # update only data rate & input multiplexing (luckily they are right beside eachother)
+            start_addr = ADCReg.REG_MODE2.value
+            register_list = [mode2_register_value, inpmux_register_value]
+        else:
+            # Only write the register value 0x06 (INPMUX), which stores info
+            # about how the multiplexer should read from the ADC channels (input pins).
+            start_addr = ADCReg.REG_INPMUX.value
+            register_list = [inpmux_register_value]
+
+        write_reg_cmd = ADCCommands.unsafe_write_register_command(
+            start_addr, register_list
+        )
+
+        # write config registers, start the adc's conversions, wait, then read registers
+        return (
+            write_reg_cmd + ADCCommands.start_adc_command(ADCNum.ADC_1.value),
+            conversion_delay,
+            ADCCommands.read_adc_command(ADCNum.ADC_1.value, ADC_VOLTAGE_READ_LEN),
+        )
 
     @staticmethod
     def check_for_int(target_list):

--- a/src/edgepi/adc/adc_commands.py
+++ b/src/edgepi/adc/adc_commands.py
@@ -38,12 +38,12 @@ class ADCCommands:
         command = [ADCComs.COM_WREG.value + address, len(values) - 1]
         return command + values
 
-    def start_adc(self, adc_num: ADCReadInfo):
+    def start_adc_command(self, adc_num: ADCReadInfo):
         """Command to start ADC conversions"""
         _logger.debug("Command to send is %s", ([adc_num.start_cmd]))
         return [adc_num.start_cmd]
 
-    def read_adc(self, adc_num: ADCReadInfo):
+    def read_adc_command(self, adc_num: ADCReadInfo):
         """
         Returns the command to read from the ADC, after waiting the required time for
         conversions to take effect
@@ -53,12 +53,12 @@ class ADCCommands:
         # the 6 results bytes we care about.
         return [adc_num.read_cmd] + [255] * ADC_VOLTAGE_READ_LEN
 
-    def stop_adc(self, adc_num: ADCReadInfo):
+    def stop_adc_command(self, adc_num: ADCReadInfo):
         """Command to stop ADC"""
         _logger.debug("Command to send is %s", ([adc_num.stop_cmd]))
         return [adc_num.stop_cmd]
 
-    def reset_adc(self):
+    def reset_adc_command(self):
         """Command to reset ADC"""
         _logger.debug("Command to send is %s", ([ADCComs.COM_RESET.value]))
         return [ADCComs.COM_RESET.value]

--- a/src/edgepi/adc/adc_commands.py
+++ b/src/edgepi/adc/adc_commands.py
@@ -33,8 +33,13 @@ class ADCCommands:
         command = [ADCComs.COM_WREG.value + address, len(values) - 1]
         return command + values
 
-    def unsafe_write_register_command(self, address, values):
-        """Trigger ADC register write - unsafe removes all checks"""
+    def unsafe_write_register_command(self, address: int, values: list[int]):
+        """
+        Trigger ADC register write - unsafe removes all arguments validation. 
+
+        Please ensure that values contains only bytes, and that address is a 
+        valid address.
+        """
         command = [ADCComs.COM_WREG.value + address, len(values) - 1]
         return command + values
 

--- a/src/edgepi/adc/adc_constants.py
+++ b/src/edgepi/adc/adc_constants.py
@@ -8,9 +8,9 @@ from edgepi.reg_helper.reg_helper import BitMask, OpCode
 
 
 ADC_NUM_REGS = 27  # number of ADC1263 registers
-ADC_VOLTAGE_READ_LEN = 6  # number of bytes per voltage read
-ADC1_NUM_DATA_BYTES = 4 # Number of data bytes for ADC 1
-ADC2_NUM_DATA_BYTES = 3 # Number of data bytes for ADC 2
+ADC_VOLTAGE_READ_LEN = 6 # number of bytes per voltage read
+ADC1_NUM_DATA_BYTES  = 4 # Number of data bytes for ADC 1
+ADC2_NUM_DATA_BYTES  = 3 # Number of data bytes for ADC 2
 
 
 @unique

--- a/src/edgepi/adc/adc_constants.py
+++ b/src/edgepi/adc/adc_constants.py
@@ -9,8 +9,8 @@ from edgepi.reg_helper.reg_helper import BitMask, OpCode
 
 ADC_NUM_REGS = 27  # number of ADC1263 registers
 ADC_VOLTAGE_READ_LEN = 6 # number of bytes per voltage read
-ADC1_NUM_DATA_BYTES  = 4 # Number of data bytes for ADC 1
-ADC2_NUM_DATA_BYTES  = 3 # Number of data bytes for ADC 2
+ADC1_NUM_DATA_BYTES = 4 # Number of data bytes for ADC 1
+ADC2_NUM_DATA_BYTES = 3 # Number of data bytes for ADC 2
 
 
 @unique

--- a/src/edgepi/adc/adc_constants.py
+++ b/src/edgepi/adc/adc_constants.py
@@ -164,6 +164,8 @@ class ConvMode(Enum):
 class ADC1DataRate(Enum):
     """ADS1263 data rates for ADC1"""
 
+    # NOTE: the op_code values (0x0, 0x1, ...) refer to the value that's read from
+    # the ADC after applying the mask.
     SPS_2P5 = OpCode(0x0, ADCReg.REG_MODE2.value, BitMask.LOW_NIBBLE.value)
     SPS_5 = OpCode(0x1, ADCReg.REG_MODE2.value, BitMask.LOW_NIBBLE.value)
     SPS_10 = OpCode(0x2, ADCReg.REG_MODE2.value, BitMask.LOW_NIBBLE.value)

--- a/src/edgepi/adc/adc_multiplexers.py
+++ b/src/edgepi/adc/adc_multiplexers.py
@@ -7,9 +7,6 @@ from edgepi.adc.adc_constants import ADCChannel as CH, AllowedChannels, ADCReg
 
 _logger = logging.getLogger(__name__)
 
-MUXS_PER_ADC = 2
-NUM_CHANNELS = 11
-
 
 class ChannelNotAvailableError(ValueError):
     """
@@ -17,51 +14,18 @@ class ChannelNotAvailableError(ValueError):
     due to RTD_EN status.
     """
 
-
-def _format_mux_values(mux_p: CH, mux_n: CH):
-    # all use cases will always update both mux_n and mux_p
-    mask = BitMask.BYTE
-    mux_p_val = mux_p.value
-    mux_n_val = mux_n.value
-
-    return mux_p_val, mux_n_val, mask
-
-def generate_mux_opcodes(adc1_mux: (CH, CH), adc2_mux: (CH, CH)) -> list:
+def generate_mux_opcode(addx:ADCReg, mux_p:CH, mux_n:CH) -> OpCode:
     """
-    Generates list of OpCodes for updating input multiplexer mapping.
-    Updates both positive and negative multiplexers.
+    Generates OpCode for updating input multiplexer mapping.
 
-    Args:
-        `adc1_mux` (ADCChannel, ADCChannel): The new channel values for for updating
-            multiplexer mapping for adc1. The first is mux_p, the second is mux_n.
-        `adc2_mux` (ADCChannel, ADCChannel): The new channel values for for updating
-            multiplexer mapping for adc2. The first is mux_p, the second is mux_n.
-
-        Note: both of the above must be tuples must be formatted as (mux_p_val, mux_n_val)
-
-    Returns:
-        `list`: OpCodes for updated multiplexer mapping
+    We know that mux_p_val can never be larger than 15 (are a byte),
+    because mux_p and mux_n are ADCChannel.
     """
-    mux_opcodes = []
-
-    def do_opcode(addx, mux_p: CH, mux_n: CH):
-        # not updating mux's for this adc_num (no args passed)
-        if mux_p is None or mux_n is None:
-            return []
-
-        # NOTE: for this function, we know that mux_p_val can never be larger than 15, 
-        # because mux_p and mux_n are ADCChannel
-        mux_p_val, mux_n_val, mask = _format_mux_values(mux_p, mux_n)
-
-        adc_x_ch_bits = (mux_p_val << 4) + mux_n_val
-        return [OpCode(adc_x_ch_bits, addx.value, mask.value)]
-
-    # ADCReg.REG_INPMUX controls multiplexing for ad1, whileADCReg.REG_ADC2MUX controls
-    # multiplexing for adc2
-    mux_opcodes += do_opcode(ADCReg.REG_INPMUX, adc1_mux[0], adc1_mux[1])
-    mux_opcodes += do_opcode(ADCReg.REG_ADC2MUX, adc2_mux[0], adc2_mux[1])
-
-    return mux_opcodes
+    return OpCode(
+        op_code=(mux_p.value << 4) + mux_n.value,
+        reg_address=addx.value,
+        op_mask=BitMask.BYTE.value
+    )
 
 def validate_channels_allowed(channels: list, rtd_enabled: bool):
     """

--- a/src/edgepi/adc/adc_multiplexers.py
+++ b/src/edgepi/adc/adc_multiplexers.py
@@ -43,8 +43,11 @@ def validate_channels_allowed(channels: list, rtd_enabled: bool):
         else AllowedChannels.RTD_OFF.value
     )
     if any((chan not in allowed_channels) for chan in channels):
-        unavaliable_channel = next(chan for chan in channels if (chan not in allowed_channels))
+        unavaliable_channels = ",".join(
+            f"AIN{chan.value}" for chan in channels 
+            if chan not in allowed_channels
+        )
         raise ChannelNotAvailableError(
-            f"Channel 'AIN{unavaliable_channel.value}' is currently not available. "
+            f"The following channels are currently not avaliable: {unavaliable_channels}. "
             "Disable RTD in order to use."
         )

--- a/src/edgepi/adc/adc_multiplexers.py
+++ b/src/edgepi/adc/adc_multiplexers.py
@@ -42,9 +42,9 @@ def validate_channels_allowed(channels: list, rtd_enabled: bool):
         if rtd_enabled
         else AllowedChannels.RTD_OFF.value
     )
-    for chan in channels:
-        if chan not in allowed_channels:
-            raise ChannelNotAvailableError(
-                f"Channel 'AIN{chan.value}' is currently not available. "
-                "Disable RTD in order to use."
-            )
+    if any((chan not in allowed_channels) for chan in channels):
+        unavaliable_channel = next(chan for chan in channels if (chan not in allowed_channels))
+        raise ChannelNotAvailableError(
+            f"Channel 'AIN{unavaliable_channel.value}' is currently not available. "
+            "Disable RTD in order to use."
+        )

--- a/src/edgepi/adc/adc_multiplexers.py
+++ b/src/edgepi/adc/adc_multiplexers.py
@@ -52,7 +52,8 @@ def generate_mux_opcodes(adc1_reg, adc1_mux, adc2_reg, adc2_mux):
         if mux_p is None or mux_n is None:
             return []
 
-        # NOTE: for this function, we know that mux_p_val can never be larger than 15, because mux_p and mux_n are ADCChannel
+        # NOTE: for this function, we know that mux_p_val can never be larger than 15, 
+        # because mux_p and mux_n are ADCChannel
         mux_p_val, mux_n_val, mask = _format_mux_values(mux_p, mux_n)
 
         adc_x_ch_bits = (mux_p_val << 4) + mux_n_val
@@ -78,8 +79,9 @@ def validate_channels_allowed(channels: list, rtd_enabled: bool):
         if rtd_enabled
         else AllowedChannels.RTD_OFF.value
     )
-    for ch in channels:
-        if ch not in allowed_channels:
+    for chan in channels:
+        if chan not in allowed_channels:
             raise ChannelNotAvailableError(
-                f"Channel 'AIN{ch.value}' is currently not available. Disable RTD in order to use."
+                f"Channel 'AIN{chan.value}' is currently not available. "
+                "Disable RTD in order to use."
             )

--- a/src/edgepi/adc/adc_multiplexers.py
+++ b/src/edgepi/adc/adc_multiplexers.py
@@ -76,15 +76,15 @@ def generate_mux_opcodes(mux_updates: dict):
 def DEV_generate_mux_opcodes(key1, value1, key2, value2):
     mux_opcodes = []
 
-    def do_opcode(addx, mux_p, mux_n):
+    def do_opcode(addx, mux_p: CH, mux_n: CH):
         # not updating mux's for this adc_num (no args passed)
         if mux_p is None or mux_n is None:
             return []
 
+        # NOTE: for this function, we know that mux_p_val can never be larger than 15, because mux_p and mux_n are ADCChannel
         mux_p_val, mux_n_val, mask = _format_mux_values(mux_p, mux_n)
 
-        adc_x_ch_bits = pack("uint:4, uint:4", mux_p_val, mux_n_val).uint
-
+        adc_x_ch_bits = (mux_p_val << 4) + mux_n_val
         return [OpCode(adc_x_ch_bits, addx.value, mask.value)]
 
     mux_opcodes += do_opcode(key1, value1[0], value1[1])

--- a/src/edgepi/adc/adc_multiplexers.py
+++ b/src/edgepi/adc/adc_multiplexers.py
@@ -46,7 +46,7 @@ def generate_mux_opcodes(mux_updates: dict):
     Returns:
         `list`: OpCodes for updated multiplexer mapping
     """
-    _logger.debug(f"generate_mux_opcodes: mux updates = {mux_updates}")
+    _logger.debug("generate_mux_opcodes: mux updates = {}".format(mux_updates))
 
     mux_opcodes = []
     # generate OpCodes for mux updates
@@ -62,8 +62,7 @@ def generate_mux_opcodes(mux_updates: dict):
 
         mux_opcodes.append(OpCode(adc_x_ch_bits, addx.value, mask.value))
 
-    _logger.debug(f"mux opcodes = {mux_opcodes}")
-
+    _logger.debug("mux opcodes = {}".format(mux_opcodes))
     return mux_opcodes
 
 def validate_channels_allowed(channels: list, rtd_enabled: bool):

--- a/src/edgepi/adc/adc_multiplexers.py
+++ b/src/edgepi/adc/adc_multiplexers.py
@@ -37,7 +37,7 @@ def generate_mux_opcodes(adc1_mux: (CH, CH), adc2_mux: (CH, CH)) -> list:
         `adc2_mux` (ADCChannel, ADCChannel): The new channel values for for updating
             multiplexer mapping for adc2. The first is mux_p, the second is mux_n.
 
-        Note: both of the above must be dictionaries formatted as (mux_p_val, mux_n_val)
+        Note: both of the above must be tuples must be formatted as (mux_p_val, mux_n_val)
 
     Returns:
         `list`: OpCodes for updated multiplexer mapping

--- a/src/edgepi/adc/adc_state.py
+++ b/src/edgepi/adc/adc_state.py
@@ -51,11 +51,10 @@ class ADCState:
         A static method that uses the provided register map to determine a single adc_property, 
         rather than computing all of them
         """
-        # value of this adc_property's register
-        reg_value = reg_map[adc_property.value.addx]
+        register_value = reg_map[adc_property.value.addx]
         # get value of bits corresponding to this property by letting through only the bits
         # that were "masked" when setting this property (clear all bits except the property bits)
-        adc_property_bits = (~adc_property.value.mask) & reg_value
+        adc_property_bits = (~adc_property.value.mask) & register_value
         # name of current value of this adc_property
         adc_property_value = adc_property.value.values[adc_property_bits]
         return adc_property_value

--- a/src/edgepi/adc/adc_state.py
+++ b/src/edgepi/adc/adc_state.py
@@ -47,7 +47,8 @@ class ADCState:
 
     def get_state(reg_map: dict, adc_property: ADCProperties) -> PropertyValue:
         """
-        A static method that uses a provided register map to determine a single required adc_property
+        A static method that uses the provided register map to determine a single adc_property, 
+        rather than computing all of them
         """
         # value of this adc_property's register
         reg_value = reg_map[adc_property.value.addx]

--- a/src/edgepi/adc/adc_state.py
+++ b/src/edgepi/adc/adc_state.py
@@ -24,7 +24,7 @@ class ADCReadFields:
 
 class ADCState:
     """ADC state intended for reading by users"""
-# pylint: disable=too-many-instance-attributes
+    # pylint: disable=too-many-instance-attributes
     def __init__(self, reg_map: dict):
         self.__reg_map = reg_map
         self.adc_1: ADCReadFields = ADCReadFields(
@@ -44,6 +44,19 @@ class ADCState:
         self.checksum_mode: PropertyValue = self.__get_state(ADCProperties.CHECK_MODE)
         self.rtd_adc: ADCNum = self.__get_rtd_adc_num()
         self.rtd_mode: RTDModes = self.__get_rtd_mode()
+
+    def get_state(reg_map: dict, adc_property: ADCProperties) -> PropertyValue:
+        """
+        A static method that uses a provided register map to determine a single required adc_property
+        """
+        # value of this adc_property's register
+        reg_value = reg_map[adc_property.value.addx]
+        # get value of bits corresponding to this property by letting through only the bits
+        # that were "masked" when setting this property (clear all bits except the property bits)
+        adc_property_bits = (~adc_property.value.mask) & reg_value
+        # name of current value of this adc_property
+        adc_property_value = adc_property.value.values[adc_property_bits]
+        return adc_property_value
 
     def __query_state(self, adc_property: ADCProperties) -> PropertyValue:
         """

--- a/src/edgepi/adc/adc_state.py
+++ b/src/edgepi/adc/adc_state.py
@@ -45,20 +45,6 @@ class ADCState:
         self.rtd_adc: ADCNum = self.__get_rtd_adc_num()
         self.rtd_mode: RTDModes = self.__get_rtd_mode()
 
-    @staticmethod
-    def get_state(reg_map: dict, adc_property: ADCProperties) -> PropertyValue:
-        """
-        A static method that uses the provided register map to determine a single adc_property, 
-        rather than computing all of them
-        """
-        register_value = reg_map[adc_property.value.addx]
-        # get value of bits corresponding to this property by letting through only the bits
-        # that were "masked" when setting this property (clear all bits except the property bits)
-        adc_property_bits = (~adc_property.value.mask) & register_value
-        # name of current value of this adc_property
-        adc_property_value = adc_property.value.values[adc_property_bits]
-        return adc_property_value
-
     def __query_state(self, adc_property: ADCProperties) -> PropertyValue:
         """
         Read the current state of configurable ADC properties

--- a/src/edgepi/adc/adc_state.py
+++ b/src/edgepi/adc/adc_state.py
@@ -45,6 +45,7 @@ class ADCState:
         self.rtd_adc: ADCNum = self.__get_rtd_adc_num()
         self.rtd_mode: RTDModes = self.__get_rtd_mode()
 
+    @staticmethod
     def get_state(reg_map: dict, adc_property: ADCProperties) -> PropertyValue:
         """
         A static method that uses the provided register map to determine a single adc_property, 

--- a/src/edgepi/adc/adc_status.py
+++ b/src/edgepi/adc/adc_status.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from enum import Enum, unique
 
-from bitstring import pack
+import bitstring
 
 @unique
 class ADCStatusBit(Enum):
@@ -97,7 +97,7 @@ def get_adc_status(status_code: int) -> dict:
     """
     status_dict = {}
 
-    status_byte = pack("uint:8", status_code)
+    status_byte = bitstring.pack("uint:8", status_code)
 
     # check each bit in status_byte
     for bit_num in ADCStatusBit:

--- a/src/edgepi/adc/adc_status.py
+++ b/src/edgepi/adc/adc_status.py
@@ -2,9 +2,9 @@
 
 from dataclasses import dataclass
 from enum import Enum, unique
+from functools import lru_cache
 
-import bitstring
-
+from bitstring import pack
 
 @unique
 class ADCStatusBit(Enum):
@@ -87,7 +87,7 @@ _fault_msg_map = {
     ADCStatusBit.RESET: (ADCStatusMsg.RESET_FALSE, ADCStatusMsg.RESET_TRUE),
 }
 
-
+@lru_cache(maxsize=128)
 def get_adc_status(status_code: int) -> dict:
     """Generates a dictionary of ADC Status objects
 
@@ -99,7 +99,7 @@ def get_adc_status(status_code: int) -> dict:
     """
     status_dict = {}
 
-    status_byte = bitstring.pack("uint:8", status_code)
+    status_byte = pack("uint:8", status_code)
 
     # check each bit in status_byte
     for bit_num in ADCStatusBit:

--- a/src/edgepi/adc/adc_status.py
+++ b/src/edgepi/adc/adc_status.py
@@ -2,7 +2,6 @@
 
 from dataclasses import dataclass
 from enum import Enum, unique
-from functools import lru_cache
 
 from bitstring import pack
 
@@ -87,7 +86,6 @@ _fault_msg_map = {
     ADCStatusBit.RESET: (ADCStatusMsg.RESET_FALSE, ADCStatusMsg.RESET_TRUE),
 }
 
-@lru_cache(maxsize=128)
 def get_adc_status(status_code: int) -> dict:
     """Generates a dictionary of ADC Status objects
 

--- a/src/edgepi/adc/adc_voltage.py
+++ b/src/edgepi/adc/adc_voltage.py
@@ -6,7 +6,7 @@ import logging
 from bitstring import BitArray
 from edgepi.adc.adc_constants import ADCReadInfo, ADCNum, ADC1_NUM_DATA_BYTES, ADC2_NUM_DATA_BYTES
 from edgepi.calibration.calibration_constants import CalibParam
-from edgepi.utilities.utilities import bitstring_from_list, DEV_bitstring_from_list, combine_to_uint32
+from edgepi.utilities.utilities import bitstring_from_list, combine_to_uint32
 
 
 # TODO: retrieve these values from EEPROM once added
@@ -55,7 +55,6 @@ def _adc_voltage_to_input_voltage(v_in: float, gain: float, offset: float):
     step_up_ratio = (STEP_DOWN_RESISTOR_1 + STEP_DOWN_RESISTOR_2) / STEP_DOWN_RESISTOR_2
     return v_in * step_up_ratio * gain + offset
 
-
 def code_to_voltage(code: list[int], adc_info: ADCReadInfo, calibs: CalibParam) -> float:
     """
     Converts ADC voltage read digital code to output voltage (voltage measured at terminal block)
@@ -70,16 +69,23 @@ def code_to_voltage(code: list[int], adc_info: ADCReadInfo, calibs: CalibParam) 
     Returns:
         `float`: voltage value (V) corresponding to `code`
     """
-    code_bits = bitstring_from_list(code[:adc_info.num_data_bytes])
-    num_bits = adc_info.num_data_bytes * 8
-    code_val = code_bits.uint
 
-    if _is_negative_voltage(code_bits):
+    num_bits = adc_info.num_data_bytes * 8
+    is_negative_voltage = (code[0] & 0x80) != 0 # check if first bit of sequence is a 1
+    if adc_info.num_data_bytes == ADC1_NUM_DATA_BYTES:
+        code_val = combine_to_uint32(code[0], code[1], code[2], code[3])
+    elif adc_info.num_data_bytes == ADC2_NUM_DATA_BYTES:
+        code_val = combine_to_uint32(0, code[0], code[1], code[2])
+    else:
+        raise Exception(
+            f"code has unexpected number of bytes {adc_info.num_data_bytes}, expected 4 for ADC1 or 3 for ADC2"
+        )
+
+    if is_negative_voltage:
         code_val = code_val - 2**num_bits
 
     v_in = _code_to_input_voltage(code_val, REFERENCE_VOLTAGE, num_bits)
     v_out = _adc_voltage_to_input_voltage(v_in, calibs.gain, calibs.offset)
-
     return v_out
 
 def code_to_voltage_single_ended(code: list[int], adc_info: ADCReadInfo, calibs: CalibParam):
@@ -97,10 +103,16 @@ def code_to_voltage_single_ended(code: list[int], adc_info: ADCReadInfo, calibs:
         `float`: voltage value (V) corresponding to `code`
     """
 
-    code_bits = DEV_bitstring_from_list(code[:adc_info.num_data_bytes]) # 0.263
-    is_negative_voltage = code_bits[0] == 1
     num_bits = adc_info.num_data_bytes * 8
-    code_val = code_bits.uint
+    is_negative_voltage = (code[0] & 0x80) != 0 # check if first bit of sequence is a 1
+    if adc_info.num_data_bytes == ADC1_NUM_DATA_BYTES:
+        code_val = combine_to_uint32(code[0], code[1], code[2], code[3])
+    elif adc_info.num_data_bytes == ADC2_NUM_DATA_BYTES:
+        code_val = combine_to_uint32(0, code[0], code[1], code[2])
+    else:
+        raise Exception(
+            f"code has unexpected number of bytes {adc_info.num_data_bytes}, expected 4 for ADC1 or 3 for ADC2"
+        )
 
     if is_negative_voltage and adc_info.num_data_bytes == ADC1_NUM_DATA_BYTES:
         code_val = code_val - ADC1_UPPER_LIMIT
@@ -116,45 +128,6 @@ def code_to_voltage_single_ended(code: list[int], adc_info: ADCReadInfo, calibs:
 
     return v_out
 
-def DEV_code_to_voltage_single_ended(code: list[int], adc_info: ADCReadInfo, calibs: CalibParam): # 0.049
-    """
-    Converts ADC voltage read digital code to output voltage (voltage measured at terminal block)
-
-    Args:
-        `code` (list[int]): code bytes retrieved from ADC voltage read
-
-        `adc_info` (ADCReadInfo): data about this adc's voltage reading configuration
-
-        `calibs` (CalibParam): voltage reading gain and offset calibration values
-
-    Returns:
-        `float`: voltage value (V) corresponding to `code`
-    """
-
-    num_bits = adc_info.num_data_bytes * 8
-    # TODO: confirm this for ADC2
-    is_negative_voltage = (code[0] & 0x80) != 0
-    if adc_info.num_data_bytes == ADC1_NUM_DATA_BYTES:
-        code_val = combine_to_uint32(code[0], code[1], code[2], code[3])
-    elif adc_info.num_data_bytes == ADC2_NUM_DATA_BYTES:
-        code_val = combine_to_uint32(0, code[0], code[1], code[2]) # TODO: test this
-    else:
-        raise Exception("unexpected number of data bytes")
-
-    if is_negative_voltage and adc_info.num_data_bytes == ADC1_NUM_DATA_BYTES:
-        code_val = code_val - ADC1_UPPER_LIMIT
-    elif is_negative_voltage and adc_info.num_data_bytes == ADC2_NUM_DATA_BYTES:
-        code_val = code_val - ADC2_UPPER_LIMIT
-    elif adc_info.num_data_bytes == ADC1_NUM_DATA_BYTES:
-        code_val = code_val + ADC1_UPPER_LIMIT
-    elif adc_info.num_data_bytes == ADC2_NUM_DATA_BYTES:
-        code_val = code_val + ADC2_UPPER_LIMIT
-
-    v_in = _code_to_input_voltage(code_val, REFERENCE_VOLTAGE, num_bits) # 0.062
-    v_out = _adc_voltage_to_input_voltage(v_in, calibs.gain, calibs.offset)
-
-    return v_out
-
 def code_to_temperature(
     code: list[int],
     ref_resistance: float,
@@ -163,7 +136,7 @@ def code_to_temperature(
     rtd_calib_gain: float,
     rtd_calib_offset: float,
     adc_num: ADCNum
-    ) -> float:
+) -> float:
     """
     Converts ADC voltage read digital code to temperature. Intended for use in RTD sampling.
 

--- a/src/edgepi/adc/adc_voltage.py
+++ b/src/edgepi/adc/adc_voltage.py
@@ -54,7 +54,12 @@ def _adc_voltage_to_input_voltage(v_in: float, gain: float, offset: float):
     return v_in * step_up_ratio * gain + offset
 
 
-def code_to_voltage(code: list[int], adc_info: ADCReadInfo, calibs: CalibParam, single_ended: bool) -> float:
+def code_to_voltage(
+    code: list[int],
+    adc_info: ADCReadInfo,
+    calibs: CalibParam,
+    single_ended: bool,
+) -> float:
     """
     Converts ADC voltage read digital code to output voltage (voltage measured at terminal block)
 
@@ -62,7 +67,8 @@ def code_to_voltage(code: list[int], adc_info: ADCReadInfo, calibs: CalibParam, 
         `code` (list[int]): code bytes retrieved from ADC voltage read
         `adc_info` (ADCReadInfo): data about this adc's voltage reading configuration
         `calibs` (CalibParam): voltage reading gain and offset calibration values
-        `single_ended` (bool): whether the mode should be single ended or not single ended (differential)
+        `single_ended` (bool): whether the mode should be single ended or not single ended
+                               (differential)
 
     Returns:
         `float`: voltage value (V) corresponding to `code`
@@ -113,7 +119,8 @@ def code_to_temperature(
         `code` (list[int]): code bytes retrieved from ADC voltage read
         `ref_resistance` (float): EdgePi-specific RTD reference resistance (Ohms)
         `rtd_sensor_resistance` (float): RTD material-dependent resistance value (Ohms)
-        `rtd_sensor_resistance_variation` (float): RTD model-dependent resistance variation (Ohms/°C)
+        `rtd_sensor_resistance_variation` (float): RTD model-dependent resistance variation
+                                                   (Ohms/°C)
 
     Returns:
         `float`: temperature value (°C) corresponding to `code`

--- a/src/edgepi/adc/adc_voltage.py
+++ b/src/edgepi/adc/adc_voltage.py
@@ -26,7 +26,7 @@ def _is_negative_voltage(code: list[int]):
     Determines if voltage code is negative value
     """
     # check if first bit of the first integer is a 1
-    return (code[0] & 0x80) != 0 
+    return (code[0] & 0x80) != 0
 
 
 def _code_to_input_voltage(code: int, v_ref: float, num_bits: int):
@@ -77,8 +77,9 @@ def code_to_voltage(code: list[int], adc_info: ADCReadInfo, calibs: CalibParam) 
     elif adc_info.num_data_bytes == ADC2_NUM_DATA_BYTES:
         code_val = combine_to_uint32(0, code[0], code[1], code[2])
     else:
-        raise Exception(
-            f"code has unexpected number of bytes {adc_info.num_data_bytes}, expected 4 for ADC1 or 3 for ADC2"
+        raise ValueError(
+            f"code has unexpected number of bytes {adc_info.num_data_bytes}, "
+            "expected 4 for ADC1 or 3 for ADC2"
         )
 
     if _is_negative_voltage(code):
@@ -109,8 +110,9 @@ def code_to_voltage_single_ended(code: list[int], adc_info: ADCReadInfo, calibs:
     elif adc_info.num_data_bytes == ADC2_NUM_DATA_BYTES:
         code_val = combine_to_uint32(0, code[0], code[1], code[2])
     else:
-        raise Exception(
-            f"code has unexpected number of bytes {adc_info.num_data_bytes}, expected 4 for ADC1 or 3 for ADC2"
+        raise ValueError(
+            f"code has unexpected number of bytes {adc_info.num_data_bytes}, "
+            "expected 4 for ADC1 or 3 for ADC2"
         )
 
     if _is_negative_voltage(code) and adc_info.num_data_bytes == ADC1_NUM_DATA_BYTES:

--- a/src/edgepi/adc/adc_voltage.py
+++ b/src/edgepi/adc/adc_voltage.py
@@ -6,7 +6,7 @@ import logging
 from bitstring import BitArray
 from edgepi.adc.adc_constants import ADCReadInfo, ADCNum, ADC1_NUM_DATA_BYTES, ADC2_NUM_DATA_BYTES
 from edgepi.calibration.calibration_constants import CalibParam
-from edgepi.utilities.utilities import bitstring_from_list, DEV_bitstring_from_list
+from edgepi.utilities.utilities import bitstring_from_list, DEV_bitstring_from_list, combine_to_uint32
 
 
 # TODO: retrieve these values from EEPROM once added
@@ -78,7 +78,6 @@ def code_to_voltage(code: list[int], adc_info: ADCReadInfo, calibs: CalibParam) 
         code_val = code_val - 2**num_bits
 
     v_in = _code_to_input_voltage(code_val, REFERENCE_VOLTAGE, num_bits)
-
     v_out = _adc_voltage_to_input_voltage(v_in, calibs.gain, calibs.offset)
 
     return v_out
@@ -97,13 +96,15 @@ def code_to_voltage_single_ended(code: list[int], adc_info: ADCReadInfo, calibs:
     Returns:
         `float`: voltage value (V) corresponding to `code`
     """
-    code_bits = DEV_bitstring_from_list(code[:adc_info.num_data_bytes])
+
+    code_bits = DEV_bitstring_from_list(code[:adc_info.num_data_bytes]) # 0.263
+    is_negative_voltage = code_bits[0] == 1
     num_bits = adc_info.num_data_bytes * 8
     code_val = code_bits.uint
 
-    if _is_negative_voltage(code_bits) and adc_info.num_data_bytes == ADC1_NUM_DATA_BYTES:
+    if is_negative_voltage and adc_info.num_data_bytes == ADC1_NUM_DATA_BYTES:
         code_val = code_val - ADC1_UPPER_LIMIT
-    elif _is_negative_voltage(code_bits) and adc_info.num_data_bytes == ADC2_NUM_DATA_BYTES:
+    elif is_negative_voltage and adc_info.num_data_bytes == ADC2_NUM_DATA_BYTES:
         code_val = code_val - ADC2_UPPER_LIMIT
     elif adc_info.num_data_bytes == ADC1_NUM_DATA_BYTES:
         code_val = code_val + ADC1_UPPER_LIMIT
@@ -111,6 +112,45 @@ def code_to_voltage_single_ended(code: list[int], adc_info: ADCReadInfo, calibs:
         code_val = code_val + ADC2_UPPER_LIMIT
 
     v_in = _code_to_input_voltage(code_val, REFERENCE_VOLTAGE, num_bits)
+    v_out = _adc_voltage_to_input_voltage(v_in, calibs.gain, calibs.offset)
+
+    return v_out
+
+def DEV_code_to_voltage_single_ended(code: list[int], adc_info: ADCReadInfo, calibs: CalibParam): # 0.049
+    """
+    Converts ADC voltage read digital code to output voltage (voltage measured at terminal block)
+
+    Args:
+        `code` (list[int]): code bytes retrieved from ADC voltage read
+
+        `adc_info` (ADCReadInfo): data about this adc's voltage reading configuration
+
+        `calibs` (CalibParam): voltage reading gain and offset calibration values
+
+    Returns:
+        `float`: voltage value (V) corresponding to `code`
+    """
+
+    num_bits = adc_info.num_data_bytes * 8
+    # TODO: confirm this for ADC2
+    is_negative_voltage = (code[0] & 0x80) != 0
+    if adc_info.num_data_bytes == ADC1_NUM_DATA_BYTES:
+        code_val = combine_to_uint32(code[0], code[1], code[2], code[3])
+    elif adc_info.num_data_bytes == ADC2_NUM_DATA_BYTES:
+        code_val = combine_to_uint32(0, code[0], code[1], code[2]) # TODO: test this
+    else:
+        raise Exception("unexpected number of data bytes")
+
+    if is_negative_voltage and adc_info.num_data_bytes == ADC1_NUM_DATA_BYTES:
+        code_val = code_val - ADC1_UPPER_LIMIT
+    elif is_negative_voltage and adc_info.num_data_bytes == ADC2_NUM_DATA_BYTES:
+        code_val = code_val - ADC2_UPPER_LIMIT
+    elif adc_info.num_data_bytes == ADC1_NUM_DATA_BYTES:
+        code_val = code_val + ADC1_UPPER_LIMIT
+    elif adc_info.num_data_bytes == ADC2_NUM_DATA_BYTES:
+        code_val = code_val + ADC2_UPPER_LIMIT
+
+    v_in = _code_to_input_voltage(code_val, REFERENCE_VOLTAGE, num_bits) # 0.062
     v_out = _adc_voltage_to_input_voltage(v_in, calibs.gain, calibs.offset)
 
     return v_out

--- a/src/edgepi/adc/adc_voltage.py
+++ b/src/edgepi/adc/adc_voltage.py
@@ -3,7 +3,6 @@
 
 import logging
 
-from bitstring import BitArray
 from edgepi.adc.adc_constants import ADCReadInfo, ADCNum, ADC1_NUM_DATA_BYTES, ADC2_NUM_DATA_BYTES
 from edgepi.calibration.calibration_constants import CalibParam
 from edgepi.utilities.utilities import bitstring_from_list, combine_to_uint32

--- a/src/edgepi/adc/adc_voltage.py
+++ b/src/edgepi/adc/adc_voltage.py
@@ -21,11 +21,12 @@ ADC2_UPPER_LIMIT = 8388608
 _logger = logging.getLogger(__name__)
 
 
-def _is_negative_voltage(code: BitArray):
+def _is_negative_voltage(code: list[int]):
     """
     Determines if voltage code is negative value
     """
-    return code[0] == 1
+    # check if first bit of the first integer is a 1
+    return (code[0] & 0x80) != 0 
 
 
 def _code_to_input_voltage(code: int, v_ref: float, num_bits: int):
@@ -71,7 +72,6 @@ def code_to_voltage(code: list[int], adc_info: ADCReadInfo, calibs: CalibParam) 
     """
 
     num_bits = adc_info.num_data_bytes * 8
-    is_negative_voltage = (code[0] & 0x80) != 0 # check if first bit of sequence is a 1
     if adc_info.num_data_bytes == ADC1_NUM_DATA_BYTES:
         code_val = combine_to_uint32(code[0], code[1], code[2], code[3])
     elif adc_info.num_data_bytes == ADC2_NUM_DATA_BYTES:
@@ -81,7 +81,7 @@ def code_to_voltage(code: list[int], adc_info: ADCReadInfo, calibs: CalibParam) 
             f"code has unexpected number of bytes {adc_info.num_data_bytes}, expected 4 for ADC1 or 3 for ADC2"
         )
 
-    if is_negative_voltage:
+    if _is_negative_voltage(code):
         code_val = code_val - 2**num_bits
 
     v_in = _code_to_input_voltage(code_val, REFERENCE_VOLTAGE, num_bits)
@@ -104,7 +104,6 @@ def code_to_voltage_single_ended(code: list[int], adc_info: ADCReadInfo, calibs:
     """
 
     num_bits = adc_info.num_data_bytes * 8
-    is_negative_voltage = (code[0] & 0x80) != 0 # check if first bit of sequence is a 1
     if adc_info.num_data_bytes == ADC1_NUM_DATA_BYTES:
         code_val = combine_to_uint32(code[0], code[1], code[2], code[3])
     elif adc_info.num_data_bytes == ADC2_NUM_DATA_BYTES:
@@ -114,9 +113,9 @@ def code_to_voltage_single_ended(code: list[int], adc_info: ADCReadInfo, calibs:
             f"code has unexpected number of bytes {adc_info.num_data_bytes}, expected 4 for ADC1 or 3 for ADC2"
         )
 
-    if is_negative_voltage and adc_info.num_data_bytes == ADC1_NUM_DATA_BYTES:
+    if _is_negative_voltage(code) and adc_info.num_data_bytes == ADC1_NUM_DATA_BYTES:
         code_val = code_val - ADC1_UPPER_LIMIT
-    elif is_negative_voltage and adc_info.num_data_bytes == ADC2_NUM_DATA_BYTES:
+    elif _is_negative_voltage(code) and adc_info.num_data_bytes == ADC2_NUM_DATA_BYTES:
         code_val = code_val - ADC2_UPPER_LIMIT
     elif adc_info.num_data_bytes == ADC1_NUM_DATA_BYTES:
         code_val = code_val + ADC1_UPPER_LIMIT

--- a/src/edgepi/adc/adc_voltage.py
+++ b/src/edgepi/adc/adc_voltage.py
@@ -6,7 +6,7 @@ import logging
 from bitstring import BitArray
 from edgepi.adc.adc_constants import ADCReadInfo, ADCNum, ADC1_NUM_DATA_BYTES, ADC2_NUM_DATA_BYTES
 from edgepi.calibration.calibration_constants import CalibParam
-from edgepi.utilities.utilities import bitstring_from_list
+from edgepi.utilities.utilities import bitstring_from_list, DEV_bitstring_from_list
 
 
 # TODO: retrieve these values from EEPROM once added
@@ -97,7 +97,7 @@ def code_to_voltage_single_ended(code: list[int], adc_info: ADCReadInfo, calibs:
     Returns:
         `float`: voltage value (V) corresponding to `code`
     """
-    code_bits = bitstring_from_list(code[:adc_info.num_data_bytes])
+    code_bits = DEV_bitstring_from_list(code[:adc_info.num_data_bytes])
     num_bits = adc_info.num_data_bytes * 8
     code_val = code_bits.uint
 

--- a/src/edgepi/adc/edgepi_adc.py
+++ b/src/edgepi/adc/edgepi_adc.py
@@ -1005,8 +1005,6 @@ class EdgePiADC(SPI):
         is active.
 
         This function only supports ADC 1, and changes the conversion mode to PULSE automatically.
-
-        TODO: if even more performance is needed, continuous mode might only need to sleep for the first conversion!
         """
         analog_in_list     = [] if analog_in_list is None else analog_in_list
         differential_pairs = [] if differential_pairs is None else differential_pairs

--- a/src/edgepi/adc/edgepi_adc.py
+++ b/src/edgepi/adc/edgepi_adc.py
@@ -613,7 +613,6 @@ class EdgePiADC(SPI):
             return True
         return False
 
-    # TODO: will this be updated when rtd is set to be on? will the state cache pick up hardware changes? probably not...
     def __get_rtd_state(self):
         """
         Get RTD state this includes the current mode (on/off) and the adc type being used
@@ -1043,21 +1042,17 @@ class EdgePiADC(SPI):
             [(diff_mode.value.mux_p, diff_mode.value.mux_n) for diff_mode in differential_pairs]
         )
 
-        # TODO: what happens if the SPI read fails (or something else fails in ADC during)?
-        # Register values will be unknown until we read from it again?
         data_list = self.spi_apply_adc_commands([
             # get instructions we need to send to perform a read of each pin
             ADCCommands.read_command_tuple(
                 # the first command tuple should write the mode2 register to contain the data rate
                 mode2_register_value if i == 0 else None,
                 conversion_delay,
-                mux_p,
-                mux_n
+                mux_p, mux_n
             ) for i, (mux_p, mux_n) in enumerate(mux_pairs)
         ])
 
-        # TODO: make sure these updates work correctly
-        # update with final ADC state (for state caching)
+        # update with final ADC state we wrote (for state caching)
         EdgePiADC.__state[ADCReg.REG_MODE2.value] = mode2_register_value
         mux_p, mux_n = mux_pairs[-1]
         EdgePiADC.__state[ADCReg.REG_INPMUX.value] = generate_mux_opcode(ADCReg.REG_INPMUX, mux_p, mux_n).op_code

--- a/src/edgepi/adc/edgepi_adc.py
+++ b/src/edgepi/adc/edgepi_adc.py
@@ -116,7 +116,6 @@ class EdgePiADC(SPI):
         super().__init__(bus_num=6, dev_id=1)
         # declare instance vars before config call below
         self.enable_cache = enable_cache
-        self.adc_state_cache = None # TODO: add enable/disable mechanism
 
         # Load eeprom data and generate dictionary of calibration dataclass
         eeprom = EdgePiEEPROM()
@@ -1008,7 +1007,6 @@ class EdgePiADC(SPI):
 
         # get current register values
         register_values = self.__get_register_map()
-        print(f"reg vals: {register_values}")
         if len(register_values.values()) < 1:
             raise ValueError("Number of reg_values must be at least 1")
 
@@ -1056,9 +1054,7 @@ class EdgePiADC(SPI):
             command_tup, register_values = create_commands(-1, register_values, mux_p, mux_n)
             command_tup_list += [command_tup]
 
-        print(command_tup_list)
         data_list = self.spi_apply_adc_commands(command_tup_list)
-        print(data_list)
         
         # update with final ADC state (for state caching)
         EdgePiADC.__state = register_values
@@ -1072,8 +1068,26 @@ class EdgePiADC(SPI):
             check_code = read_data[6]
             check_crc(voltage_code, check_code)
 
-            calibs = self.__get_calibration_values(self.adc_calib_params[ADCNum.ADC_1], ADCNum.ADC_1)
+            mux_p = ADCState.get_state(EdgePiADC.__state, ADCProperties.ADC1_MUXP)
+            mux_n = ADCState.get_state(EdgePiADC.__state, ADCProperties.ADC1_MUXN)
+            
+            # assert neither mux is set to float mode
+            if CH.FLOAT in (mux_p.code, mux_n.code):
+                raise ValueError("Cannot retrieve calibration values for channel in float mode")
 
+            calib_key = mux_p.value if mux_n.code == CH.AINCOM else self.__get_diff_id(mux_p, mux_n)
+            calibs = self.adc_calib_params[ADCNum.ADC_1][calib_key]
+
+            if calibs is None:
+                _logger.error("Failed to find ADC calibration values")
+                raise CalibKeyMissingError(
+                    (
+                        "Failed to retrieve calibration values from eeprom dictionary: "
+                        f"dict is missing key = {calib_key}"
+                        f"\neeprom_calibs = \n{self.adc_calib_params[ADCNum.ADC_1]}"
+                    )
+                )
+                
             # convert from code to voltage
             if i < len(channel_list):
                 voltage_list += [code_to_voltage_single_ended(voltage_code, ADCNum.ADC_1.value, calibs)]
@@ -1091,9 +1105,5 @@ class EdgePiADC(SPI):
         Returns:
             ADCState: information about the current ADC hardware state
         """
-        # TODO: combine this cache with __get_register_map
-        # no, but make it equal?
-        if self.adc_state_cache is None or not self.enable_cache:
-            reg_values = self.__get_register_map(override_cache)
-            self.adc_state_cache = ADCState(reg_values)
-        return self.adc_state_cache
+        reg_values = self.__get_register_map(override_cache)
+        return ADCState(reg_values)

--- a/src/edgepi/adc/edgepi_adc.py
+++ b/src/edgepi/adc/edgepi_adc.py
@@ -389,7 +389,7 @@ class EdgePiADC(SPI):
 
         return self.__get_calibration_params_mux(mux_p.code, mux_n, adc_num)
 
-    def __get_calibration_params_mux(self, adc_num: ADCNum, mux_p: CH, mux_n: CH) -> float:
+    def __get_calibration_params_mux(self, adc_num: ADCNum, mux_p: CH, mux_n: CH) -> CalibParam:
         """
         Get calibration parameters using the multiplexing channels and without reading from state
         """
@@ -403,8 +403,8 @@ class EdgePiADC(SPI):
             if mux_n == CH.AINCOM
             else EdgePiADC.__get_diff_id(mux_p, mux_n)
         )
-        calibs = self.adc_calib_params[adc_num][calib_key]
 
+        calibs = self.adc_calib_params[adc_num][calib_key]
         if calibs is None:
             _logger.error("Failed to find ADC calibration values")
             raise CalibKeyMissingError(
@@ -412,6 +412,8 @@ class EdgePiADC(SPI):
                 f"dict is missing key = {calib_key}"
                 f"\neeprom_calibs = \n{self.adc_calib_params[adc_num]}"
             )
+            
+        return calibs
 
     def __continuous_time_delay(self, adc_num: ADCNum, state: ADCState):
         """Compute and enforce continuous conversion time delay"""

--- a/src/edgepi/adc/edgepi_adc.py
+++ b/src/edgepi/adc/edgepi_adc.py
@@ -988,7 +988,7 @@ class EdgePiADC(SPI):
 
     # pylint: disable=too-many-branches
     # pylint: disable=too-many-statements
-    def batch_read_samples_adc1(
+    def read_samples_adc1_batch(
         self,
         data_rate: ADC1DataRate,
         analog_in_list: Optional[list[AnalogIn]] = None,

--- a/src/edgepi/adc/edgepi_adc.py
+++ b/src/edgepi/adc/edgepi_adc.py
@@ -276,13 +276,13 @@ class EdgePiADC(SPI):
         """
         Halt voltage read conversions when ADC is set to perform continuous conversions
         """
-        stop_cmd = self.adc_ops.stop_adc(adc_num=adc_num.value)
+        stop_cmd = self.adc_ops.stop_adc_command(adc_num=adc_num.value)
         with self.spi_open():
             self.transfer(stop_cmd)
 
     def __send_start_command(self, adc_num: ADCNum):
         """Triggers ADC conversion(s)"""
-        start_cmd = self.adc_ops.start_adc(adc_num=adc_num.value)
+        start_cmd = self.adc_ops.start_adc_command(adc_num=adc_num.value)
         with self.spi_open():
             self.transfer(start_cmd)
 
@@ -568,7 +568,7 @@ class EdgePiADC(SPI):
         application of custom power-on configurations required by EdgePi.
         """
         with self.spi_open():
-            self.transfer(self.adc_ops.reset_adc())
+            self.transfer(self.adc_ops.reset_adc_command())
         self.__reapply_config()
 
     def __is_data_ready(self, adc_num: ADCNum):
@@ -1005,8 +1005,6 @@ class EdgePiADC(SPI):
 
         This function only supports ADC 1, and changes the conversion mode to PULSE automatically.
 
-        This function will not cache it's resulting register values. # TODO: change this?
-        
         TODO: if even more performance is needed, continuous mode might only need to sleep for the first conversion!
         """
         analog_in_list     = [] if analog_in_list is None else analog_in_list
@@ -1054,9 +1052,9 @@ class EdgePiADC(SPI):
 
             # write config registers, start the adc's conversions, wait, then read registers
             return (
-                write_reg_cmd + self.adc_ops.start_adc(ADCNum.ADC_1.value),
+                write_reg_cmd + self.adc_ops.start_adc_command(ADCNum.ADC_1.value),
                 conversion_delay,
-                self.adc_ops.read_adc(ADCNum.ADC_1.value),
+                self.adc_ops.read_adc_command(ADCNum.ADC_1.value),
             )
 
         mux_pairs = (

--- a/src/edgepi/adc/edgepi_adc.py
+++ b/src/edgepi/adc/edgepi_adc.py
@@ -330,7 +330,7 @@ class EdgePiADC(SPI):
     def __read_data(self, adc_num: ADCNum, data_size: int):
         """Sends command to ADC to get new voltage conversion data"""
         with self.spi_open():
-            return self.transfer(ADCCommands.read_adc_command(adc_num, data_size))
+            return self.transfer(ADCCommands.read_adc_command(adc_num.value, data_size))
 
     def __voltage_read(self, adc_num: ADCNum):
         """
@@ -579,7 +579,7 @@ class EdgePiADC(SPI):
         # required for integration testing in test_conversion_times.py
         """Utility for testing conversion times, returns True if ADC indicates new voltage data"""
         with self.spi_open():
-            read_data = self.transfer(ADCCommands.read_adc_command(adc_num, ADC_VOLTAGE_READ_LEN))
+            read_data = self.transfer(ADCCommands.read_adc_command(adc_num.value, ADC_VOLTAGE_READ_LEN))
             if adc_num is ADCNum.ADC_1:
                 return (read_data[1] & 0b01000000) == 0b01000000
             elif adc_num is ADCNum.ADC_2:

--- a/src/edgepi/adc/edgepi_adc.py
+++ b/src/edgepi/adc/edgepi_adc.py
@@ -6,7 +6,7 @@ import logging
 import time
 from typing import Optional
 
-from edgepi.adc.adc_query_lang import PropertyValue, ADCProperties
+from edgepi.adc.adc_query_lang import ADCProperties
 from edgepi.calibration.calibration_constants import CalibParam
 from edgepi.peripherals.spi import SpiDevice as SPI
 from edgepi.adc.adc_commands import ADCCommands
@@ -52,6 +52,7 @@ from edgepi.adc.adc_multiplexers import (
 from edgepi.adc.adc_conv_time import expected_initial_time_delay, expected_continuous_time_delay
 from edgepi.adc.adc_status import get_adc_status
 from edgepi.eeprom.edgepi_eeprom import EdgePiEEPROM
+from edgepi.eeprom.protobuf_assets.eeprom_data_classes.eeprom_adc_module import AdcCalibParamKeys
 from edgepi.adc.adc_state import ADCState
 from edgepi.adc.adc_exceptions import (
     ADCRegisterUpdateError,
@@ -61,6 +62,7 @@ from edgepi.adc.adc_exceptions import (
     InvalidDifferentialPairError,
     CalibKeyMissingError
 )
+
 
 _logger = logging.getLogger(__name__)
 
@@ -120,8 +122,10 @@ class EdgePiADC(SPI):
         # Load eeprom data and generate dictionary of calibration dataclass
         eeprom = EdgePiEEPROM()
         eeprom_data  = eeprom.read_edgepi_data()
-        self.adc_calib_params = {ADCNum.ADC_1:eeprom_data.adc1_calib_params.extract_ch_dict(),
-                                 ADCNum.ADC_2:eeprom_data.adc2_calib_params.extract_ch_dict(),}
+        self.adc_calib_params = {
+            ADCNum.ADC_1: eeprom_data.adc1_calib_params.extract_ch_dict(),
+            ADCNum.ADC_2: eeprom_data.adc2_calib_params.extract_ch_dict(),
+        }
         self.rtd_calib = eeprom_data.rtd_calib_params
 
         self.adc_ops = ADCCommands()
@@ -355,13 +359,13 @@ class EdgePiADC(SPI):
         # return values are the keys from adc_calib_params
         diff_pair = DifferentialPair(mux_p, mux_n)
         if diff_pair == DiffMode.DIFF_1.value:
-            return 8
+            return AdcCalibParamKeys.ADC_DIFF_1
         elif diff_pair == DiffMode.DIFF_2.value:
-            return 9
+            return AdcCalibParamKeys.ADC_DIFF_2
         elif diff_pair == DiffMode.DIFF_3.value:
-            return 10
+            return AdcCalibParamKeys.ADC_DIFF_3
         elif diff_pair == DiffMode.DIFF_4.value:
-            return 11
+            return AdcCalibParamKeys.ADC_DIFF_4
         else:
             raise InvalidDifferentialPairError(
                 f"Cannot retrieve calibration values for invalid differential pair {diff_pair}"

--- a/src/edgepi/adc/edgepi_adc.py
+++ b/src/edgepi/adc/edgepi_adc.py
@@ -973,11 +973,13 @@ class EdgePiADC(SPI):
                                         [None])
         self.__config(**args)
 
+    # pylint: disable=too-many-branches
+    # pylint: disable=too-many-statements
     def adc1_config_and_read_samples_batch(
         self,
         data_rate: ADC1DataRate,
-        analog_in_list: list[AnalogIn] = [],
-        differential_pairs: list[DiffMode] = [],
+        analog_in_list: list[AnalogIn],
+        differential_pairs: list[DiffMode],
     ) -> list:
         """
         This function sets the config, and rb

--- a/src/edgepi/adc/edgepi_adc.py
+++ b/src/edgepi/adc/edgepi_adc.py
@@ -579,7 +579,9 @@ class EdgePiADC(SPI):
         # required for integration testing in test_conversion_times.py
         """Utility for testing conversion times, returns True if ADC indicates new voltage data"""
         with self.spi_open():
-            read_data = self.transfer(ADCCommands.read_adc_command(adc_num.value, ADC_VOLTAGE_READ_LEN))
+            read_data = self.transfer(
+                ADCCommands.read_adc_command(adc_num.value, ADC_VOLTAGE_READ_LEN)
+            )
             if adc_num is ADCNum.ADC_1:
                 return (read_data[1] & 0b01000000) == 0b01000000
             elif adc_num is ADCNum.ADC_2:

--- a/src/edgepi/adc/edgepi_adc.py
+++ b/src/edgepi/adc/edgepi_adc.py
@@ -38,7 +38,8 @@ from edgepi.adc.adc_constants import (
 from edgepi.adc.adc_voltage import (
     code_to_voltage,
     code_to_temperature,
-    code_to_voltage_single_ended
+    code_to_voltage_single_ended,
+    DEV_code_to_voltage_single_ended
 )
 from edgepi.utilities.crc_8_atm import check_crc
 from edgepi.gpio.edgepi_gpio import EdgePiGPIO
@@ -237,11 +238,12 @@ class EdgePiADC(SPI):
         """
         if len(data) < 1:
             raise ValueError("Number of registers to write to must be at least 1")
-        code = self.adc_ops.write_register_command(start_addx.value, data)
+
+        code = self.adc_ops.unsafe_write_register_command(start_addx.value, data) # 0.201
         _logger.debug(f"__write_register: sending {code}")
+
         with self.spi_open():
-            out = self.transfer(code)
-        return out
+            return self.transfer(code)
 
     def __set_rtd_pin(self, enable: bool = False):
         """
@@ -316,9 +318,9 @@ class EdgePiADC(SPI):
             f"data_rate={hex(data_rate.value.op_code)}, "
             f"filter_mode={hex(filter_mode.value.op_code)}\n"
         )
-        self.__send_start_command(adc_num)
+        self.__send_start_command(adc_num) # 0.458
         # apply delay for first conversion
-        time.sleep(conv_delay / 1000)
+        time.sleep(conv_delay / 1000) # 0.580
 
     def clear_reset_bit(self):
         """
@@ -329,10 +331,10 @@ class EdgePiADC(SPI):
         """
         self.__config(reset_clear=ADCPower.RESET_CLEAR)
 
-    def __read_data(self, adc: ADCNum, data_size: int):
+    def __read_data(self, adc_num: ADCNum, data_size: int):
         """Sends command to ADC to get new voltage conversion data"""
         with self.spi_open():
-            return self.transfer([adc.value.read_cmd] + [255] * data_size)
+            return self.transfer([adc_num.value.read_cmd] + [255] * data_size)
 
     def __voltage_read(self, adc_num: ADCNum):
         """
@@ -352,6 +354,39 @@ class EdgePiADC(SPI):
         voltage_code = read_data[2 : (2 + adc_num.value.num_data_bytes)]
         check_code = read_data[6]
         check_crc(voltage_code, check_code)
+        return status_code, voltage_code, check_code
+
+    # NOTE: this function reduces the need for multiple spi calls by sending start & read in the same spi open context
+    def __start_and_read(self, adc_num: ADCNum):
+        # get state for configs relevant to conversion delay
+        state = self.get_state()
+        data_rate = (
+            state.adc_1.data_rate.code if adc_num == ADCNum.ADC_1 else state.adc_2.data_rate.code
+        )
+        filter_mode = state.filter_mode.code
+
+        conv_delay = expected_initial_time_delay(
+            adc_num, data_rate.value.op_code, filter_mode.value.op_code
+        )
+
+        start_cmd = self.adc_ops.start_adc(adc_num=adc_num.value)
+        read_cmd  = [adc_num.value.read_cmd] + [255] * ADC_VOLTAGE_READ_LEN
+        with self.spi_open():
+            self.transfer(start_cmd)
+            # apply delay for first conversion ?
+            time.sleep(conv_delay / 1000) # 0.580 # TODO: make sure this wait is absolutely neccesary
+            read_data = self.transfer(read_cmd)
+
+        if (len(read_data) - 1) != ADC_VOLTAGE_READ_LEN:
+            raise VoltageReadError(
+                f"Voltage read failed: incorrect number of bytes ({len(read_data)}) retrieved"
+            )
+
+        status_code = read_data[1]
+        voltage_code = read_data[2 : (2 + adc_num.value.num_data_bytes)]
+        check_code = read_data[6]
+        check_crc(voltage_code, check_code)
+
         return status_code, voltage_code, check_code
 
     @staticmethod
@@ -538,18 +573,15 @@ class EdgePiADC(SPI):
         Trigger a single ADC1 voltage sampling event, when performing single channel reading or
         differential reading. ADC1 must be in `PULSE` conversion mode before calling this method.
         """
-        # send command to trigger conversion
-        self.start_conversions(ADCNum.ADC_1)
-
-        # send command to read conversion data.
-        status_code, voltage_code, _ = self.__voltage_read(ADCNum.ADC_1) # 0.524
+        # send command to trigger conversion & to read conversion data.
+        status_code, voltage_code, _ = self.__start_and_read(ADCNum.ADC_1) # 1.882
 
         # log STATUS byte
-        status = get_adc_status(status_code) # 0.828
-        calibs = self.__get_calibration_values(self.adc_calib_params[ADCNum.ADC_1], ADCNum.ADC_1) # 0.065
+        status = get_adc_status(status_code) # 0.002
+        calibs = self.__get_calibration_values(self.adc_calib_params[ADCNum.ADC_1], ADCNum.ADC_1) # 0.064
 
         # convert from code to voltage
-        return code_to_voltage_single_ended(voltage_code, ADCNum.ADC_1.value, calibs) # 1.627
+        return DEV_code_to_voltage_single_ended(voltage_code, ADCNum.ADC_1.value, calibs) # 0.416
 
     def single_sample_rtd(self):
         """
@@ -683,7 +715,7 @@ class EdgePiADC(SPI):
             adc_2_mux_n = None
 
         # no multiplexer config to update
-        args = filter_dict_list_key_val(locals(), ["self", "override_rtd_validation"], [None])
+        args = filter_dict_list_key_val(locals(), ["self", "override_rtd_validation"], [None]) # 0.054
         if not args:
             return []
 
@@ -691,7 +723,7 @@ class EdgePiADC(SPI):
         if not override_rtd_validation:
             channels = list(args.values())
             rtd_enabled = self.rtd_state_cache
-            validate_channels_allowed(channels, rtd_enabled)
+            validate_channels_allowed(channels, rtd_enabled) # 0.029
 
         # NOTE: this is only commented so we can test caching the opcodes result (cannot hash dict)
         #adc_mux_updates = {
@@ -699,7 +731,7 @@ class EdgePiADC(SPI):
         #    ADCReg.REG_ADC2MUX: (adc_2_mux_p, adc_2_mux_n),
         #}
 
-        opcodes = DEV_generate_mux_opcodes(ADCReg.REG_INPMUX, (adc_1_mux_p, adc_1_mux_n), ADCReg.REG_ADC2MUX, (adc_2_mux_p, adc_2_mux_n))
+        opcodes = DEV_generate_mux_opcodes(ADCReg.REG_INPMUX, (adc_1_mux_p, adc_1_mux_n), ADCReg.REG_ADC2MUX, (adc_2_mux_p, adc_2_mux_n)) # 0.085
         return opcodes
 
     def select_differential(self, adc: ADCNum, diff_mode: DiffMode):
@@ -908,7 +940,7 @@ class EdgePiADC(SPI):
 
         # get opcodes for mapping multiplexers
         mux_args = self.__extract_mux_args(args) # 0.019
-        ops_list = self.__get_channel_assign_opcodes(  # 0.738
+        ops_list = self.__get_channel_assign_opcodes(  # 0.184
             **mux_args, override_rtd_validation=override_rtd_validation
         )
 
@@ -921,23 +953,23 @@ class EdgePiADC(SPI):
         ]
 
         # get current register values
-        reg_values = self.__get_register_map()
+        reg_values = self.__get_register_map() # 0.017
         _logger.debug(f"__config: register values before updates:\n{reg_values}")
 
         # get codes to update register values
-        updated_reg_values = apply_opcodes(dict(reg_values), ops_list) # 1.842
+        updated_reg_values = apply_opcodes(dict(reg_values), ops_list) # 0.137
         _logger.debug(f"__config: register values after updates:\n{reg_values}")
 
         # write updated reg values to ADC using a single write.
         data = [entry["value"] for entry in updated_reg_values.values()]
-        self.__write_register(ADCReg.REG_ID, data) # 1.460
+        self.__write_register(ADCReg.REG_ID, data) # 1.501
 
         # update ADC state (for state caching)
         self.__update_cache_map(updated_reg_values) # 0.053
 
         # validate updates were applied correctly
         if not override_updates_validation:
-            self.__validate_updates(updated_reg_values) # 0.059
+            self.__validate_updates(updated_reg_values) # 0.062
 
         return updated_reg_values
 

--- a/src/edgepi/adc/edgepi_adc.py
+++ b/src/edgepi/adc/edgepi_adc.py
@@ -236,10 +236,8 @@ class EdgePiADC(SPI):
         """
         if len(data) < 1:
             raise ValueError("Number of registers to write to must be at least 1")
-
-        code = self.adc_ops.unsafe_write_register_command(start_addx.value, data)
+        code = self.adc_ops.write_register_command(start_addx.value, data)
         _logger.debug(f"__write_register: sending {code}")
-
         with self.spi_open():
             return self.transfer(code)
 
@@ -674,7 +672,6 @@ class EdgePiADC(SPI):
             rtd_enabled = self.rtd_state_cache
             validate_channels_allowed(channels, rtd_enabled)
 
-        # NOTE: this is only commented so we can test caching the opcodes result (cannot hash dict)
         adc_mux_updates = {
             ADCReg.REG_INPMUX: (adc_1_mux_p, adc_1_mux_n),
             ADCReg.REG_ADC2MUX: (adc_2_mux_p, adc_2_mux_n),
@@ -778,7 +775,6 @@ class EdgePiADC(SPI):
         (ADC1RtdConfig.OFF.value if adc_num == ADCNum.ADC_1  else ADC2RtdConfig.OFF.value)
         return updates
 
-    # TODO: is this called by the edgepi portal when changes to the config shadow is made?
     def set_rtd(self, set_rtd: bool, adc_num: ADCNum = ADCNum.ADC_2):
         """
         Enable/Disable RTD with ADC type passed as arguments.

--- a/src/edgepi/adc/edgepi_adc.py
+++ b/src/edgepi/adc/edgepi_adc.py
@@ -388,7 +388,7 @@ class EdgePiADC(SPI):
         mux_p = attrgetter(f"adc_{adc_num.value.id_num}.mux_p")(state)
         mux_n = attrgetter(f"adc_{adc_num.value.id_num}.mux_n")(state)
 
-        return self.__get_calibration_params_mux(mux_p.code, mux_n, adc_num)
+        return self.__get_calibration_params_mux(adc_num, mux_p.code, mux_n.code)
 
     def __get_calibration_params_mux(self, adc_num: ADCNum, mux_p: CH, mux_n: CH) -> CalibParam:
         """

--- a/src/edgepi/adc/edgepi_adc.py
+++ b/src/edgepi/adc/edgepi_adc.py
@@ -39,7 +39,6 @@ from edgepi.adc.adc_voltage import (
     code_to_voltage,
     code_to_temperature,
     code_to_voltage_single_ended,
-    DEV_code_to_voltage_single_ended
 )
 from edgepi.utilities.crc_8_atm import check_crc
 from edgepi.gpio.edgepi_gpio import EdgePiGPIO
@@ -48,7 +47,6 @@ from edgepi.utilities.utilities import filter_dict, filter_dict_list_key_val
 from edgepi.reg_helper.reg_helper import OpCode, apply_opcodes
 from edgepi.adc.adc_multiplexers import (
     generate_mux_opcodes,
-    DEV_generate_mux_opcodes,
     validate_channels_allowed,
 )
 from edgepi.adc.adc_conv_time import expected_initial_time_delay, expected_continuous_time_delay
@@ -239,7 +237,7 @@ class EdgePiADC(SPI):
         if len(data) < 1:
             raise ValueError("Number of registers to write to must be at least 1")
 
-        code = self.adc_ops.unsafe_write_register_command(start_addx.value, data) # 0.201
+        code = self.adc_ops.unsafe_write_register_command(start_addx.value, data)
         _logger.debug(f"__write_register: sending {code}")
 
         with self.spi_open():
@@ -318,9 +316,9 @@ class EdgePiADC(SPI):
             f"data_rate={hex(data_rate.value.op_code)}, "
             f"filter_mode={hex(filter_mode.value.op_code)}\n"
         )
-        self.__send_start_command(adc_num) # 0.458
+        self.__send_start_command(adc_num)
         # apply delay for first conversion
-        time.sleep(conv_delay / 1000) # 0.580
+        time.sleep(conv_delay / 1000)
 
     def clear_reset_bit(self):
         """
@@ -354,39 +352,6 @@ class EdgePiADC(SPI):
         voltage_code = read_data[2 : (2 + adc_num.value.num_data_bytes)]
         check_code = read_data[6]
         check_crc(voltage_code, check_code)
-        return status_code, voltage_code, check_code
-
-    # NOTE: this function reduces the need for multiple spi calls by sending start & read in the same spi open context
-    def __start_and_read(self, adc_num: ADCNum):
-        # get state for configs relevant to conversion delay
-        state = self.get_state()
-        data_rate = (
-            state.adc_1.data_rate.code if adc_num == ADCNum.ADC_1 else state.adc_2.data_rate.code
-        )
-        filter_mode = state.filter_mode.code
-
-        conv_delay = expected_initial_time_delay(
-            adc_num, data_rate.value.op_code, filter_mode.value.op_code
-        )
-
-        start_cmd = self.adc_ops.start_adc(adc_num=adc_num.value)
-        read_cmd  = [adc_num.value.read_cmd] + [255] * ADC_VOLTAGE_READ_LEN
-        with self.spi_open():
-            self.transfer(start_cmd)
-            # apply delay for first conversion ?
-            time.sleep(conv_delay / 1000) # 0.580 # TODO: make sure this wait is absolutely neccesary
-            read_data = self.transfer(read_cmd)
-
-        if (len(read_data) - 1) != ADC_VOLTAGE_READ_LEN:
-            raise VoltageReadError(
-                f"Voltage read failed: incorrect number of bytes ({len(read_data)}) retrieved"
-            )
-
-        status_code = read_data[1]
-        voltage_code = read_data[2 : (2 + adc_num.value.num_data_bytes)]
-        check_code = read_data[6]
-        check_crc(voltage_code, check_code)
-
         return status_code, voltage_code, check_code
 
     @staticmethod
@@ -567,22 +532,6 @@ class EdgePiADC(SPI):
         return code_to_voltage_single_ended(voltage_code, ADCNum.ADC_1.value, calibs) if \
             single_ended  else code_to_voltage(voltage_code, ADCNum.ADC_1.value, calibs)
 
-    # NOTE: for this function, we assume single-ended mode, and that pulse mode is enabled
-    def DEV_single_sample(self) -> float:
-        """
-        Trigger a single ADC1 voltage sampling event, when performing single channel reading or
-        differential reading. ADC1 must be in `PULSE` conversion mode before calling this method.
-        """
-        # send command to trigger conversion & to read conversion data.
-        status_code, voltage_code, _ = self.__start_and_read(ADCNum.ADC_1) # 1.882
-
-        # log STATUS byte
-        status = get_adc_status(status_code) # 0.002
-        calibs = self.__get_calibration_values(self.adc_calib_params[ADCNum.ADC_1], ADCNum.ADC_1) # 0.064
-
-        # convert from code to voltage
-        return DEV_code_to_voltage_single_ended(voltage_code, ADCNum.ADC_1.value, calibs) # 0.416
-
     def single_sample_rtd(self):
         """
         Trigger a single RTD temperature sampling event. Note, to obtain valid temperature values,
@@ -715,7 +664,7 @@ class EdgePiADC(SPI):
             adc_2_mux_n = None
 
         # no multiplexer config to update
-        args = filter_dict_list_key_val(locals(), ["self", "override_rtd_validation"], [None]) # 0.054
+        args = filter_dict_list_key_val(locals(), ["self", "override_rtd_validation"], [None])
         if not args:
             return []
 
@@ -723,15 +672,15 @@ class EdgePiADC(SPI):
         if not override_rtd_validation:
             channels = list(args.values())
             rtd_enabled = self.rtd_state_cache
-            validate_channels_allowed(channels, rtd_enabled) # 0.029
+            validate_channels_allowed(channels, rtd_enabled)
 
         # NOTE: this is only commented so we can test caching the opcodes result (cannot hash dict)
-        #adc_mux_updates = {
-        #    ADCReg.REG_INPMUX: (adc_1_mux_p, adc_1_mux_n),
-        #    ADCReg.REG_ADC2MUX: (adc_2_mux_p, adc_2_mux_n),
-        #}
+        adc_mux_updates = {
+            ADCReg.REG_INPMUX: (adc_1_mux_p, adc_1_mux_n),
+            ADCReg.REG_ADC2MUX: (adc_2_mux_p, adc_2_mux_n),
+        }
 
-        opcodes = DEV_generate_mux_opcodes(ADCReg.REG_INPMUX, (adc_1_mux_p, adc_1_mux_n), ADCReg.REG_ADC2MUX, (adc_2_mux_p, adc_2_mux_n)) # 0.085
+        opcodes = generate_mux_opcodes(adc_mux_updates)
         return opcodes
 
     def select_differential(self, adc: ADCNum, diff_mode: DiffMode):
@@ -936,11 +885,11 @@ class EdgePiADC(SPI):
 
         # permit updates by rtd_mode() to turn RTD off when it's on, validate other updates
         if not override_rtd_validation:
-            self.__validate_no_rtd_conflict(args) # 0.020
+            self.__validate_no_rtd_conflict(args)
 
         # get opcodes for mapping multiplexers
-        mux_args = self.__extract_mux_args(args) # 0.019
-        ops_list = self.__get_channel_assign_opcodes(  # 0.184
+        mux_args = self.__extract_mux_args(args)
+        ops_list = self.__get_channel_assign_opcodes(
             **mux_args, override_rtd_validation=override_rtd_validation
         )
 
@@ -953,23 +902,23 @@ class EdgePiADC(SPI):
         ]
 
         # get current register values
-        reg_values = self.__get_register_map() # 0.017
+        reg_values = self.__get_register_map()
         _logger.debug(f"__config: register values before updates:\n{reg_values}")
 
         # get codes to update register values
-        updated_reg_values = apply_opcodes(dict(reg_values), ops_list) # 0.137
+        updated_reg_values = apply_opcodes(dict(reg_values), ops_list)
         _logger.debug(f"__config: register values after updates:\n{reg_values}")
 
         # write updated reg values to ADC using a single write.
         data = [entry["value"] for entry in updated_reg_values.values()]
-        self.__write_register(ADCReg.REG_ID, data) # 1.501
+        self.__write_register(ADCReg.REG_ID, data)
 
         # update ADC state (for state caching)
-        self.__update_cache_map(updated_reg_values) # 0.053
+        self.__update_cache_map(updated_reg_values)
 
         # validate updates were applied correctly
         if not override_updates_validation:
-            self.__validate_updates(updated_reg_values) # 0.062
+            self.__validate_updates(updated_reg_values)
 
         return updated_reg_values
 
@@ -1037,196 +986,101 @@ class EdgePiADC(SPI):
                                         [None])
         self.__config(**args)
 
-    # this function combines both calls, and tries to save performance where possible
-    def set_config_and_read_sample(
-        self,
-        adc_1_analog_in: AnalogIn = None,
-        adc_1_data_rate: ADC1DataRate = None,
-        adc_2_analog_in: AnalogIn = None,
-        adc_2_data_rate: ADC2DataRate = None,
-        filter_mode: FilterMode = None,
-        conversion_mode: ConvMode = None,
-        override_updates_validation: bool = False,
-        adc_1_pga: ADC1PGA = None,
-        secondary = False
-    ):
-        adc_1_ch  = self.__analog_in_to_adc_in_map.get(adc_1_analog_in)
-        adc_2_ch  = self.__analog_in_to_adc_in_map.get(adc_2_analog_in)
-
-        if adc_1_ch is None and adc_1_analog_in is not None:
-            raise TypeError(f"set_config: wrong type passed for adc_1_analog_in: {adc_1_analog_in}")
-        if adc_2_ch is None and adc_2_analog_in is not None:
-            raise TypeError(f"set_config: wrong type passed for adc_2_analog_in: {adc_2_analog_in}")
-
-        override_rtd_validation = False
-
-        # filter out self and None args
-        args = filter_dict_list_key_val(locals(), ["self", "adc_1_analog_in", "adc_2_analog_in", "secondary"], [None])
-
-        # permit updates by rtd_mode() to turn RTD off when it's on, validate other updates
-        if not override_rtd_validation:
-            self.__validate_no_rtd_conflict(args) # 0.020
-
-        # get opcodes for mapping multiplexers
-        #mux_args = self.__extract_mux_args(args) # 0.019
-        mux_args = {}
-        if "adc_1_ch" in args: mux_args["adc_1_mux_p"] = args["adc_1_ch"]
-        if "adc_2_ch" in args: mux_args["adc_2_mux_p"] = args["adc_2_ch"]
-        if "adc_1_mux_n" in args: mux_args["adc_1_mux_n"] = args["adc_1_mux_n"]
-        if "adc_2_mux_n" in args: mux_args["adc_2_mux_n"] = args["adc_2_mux_n"]
-
-        ops_list = self.__get_channel_assign_opcodes( # 0.184
-            **mux_args, override_rtd_validation=override_rtd_validation
-        )
-
-        # extract OpCode type args, since args may contain non-OpCode args
-        ops_list += [
-            entry.value
-            for entry in args.values()
-            if issubclass(entry.__class__, Enum) and isinstance(entry.value, OpCode)
-        ]
-
-        # get current register values
-        reg_values = self.__get_register_map() # 0.017
-        #print(reg_values)
-        if len(reg_values.values()) < 1:
-            raise ValueError("Number of reg_values must be at least 1")
-
-        # get codes to update register values
-        updated_reg_values = apply_opcodes(dict(reg_values), ops_list) # 0.137
-        new_edgepi_register_state = { addx: entry["value"] for (addx, entry) in updated_reg_values.items() }
-
-        # get state for configs relevant to conversion delay
-        #state = ADCState(new_edgepi_register_state)
-        #data_rate = state.adc_1.data_rate.code
-        #filter_mode = state.filter_mode.code
-
-        # TODO: ensure this is equivalent to before
-        data_rate = ADCState.get_state(new_edgepi_register_state, ADCProperties.DATA_RATE_1).code
-        filter_mode = ADCState.get_state(new_edgepi_register_state, ADCProperties.FILTER_MODE).code
-        conv_delay = expected_initial_time_delay(
-            ADCNum.ADC_1, data_rate.value.op_code, filter_mode.value.op_code
-        )
-
-        # write updated reg values to ADC using a single write.
-        #self.__write_register(ADCReg.REG_ID, data) # 1.501
-        data = [entry["value"] for entry in updated_reg_values.values()]
-        if secondary:
-            write_reg_cmd = self.adc_ops.unsafe_write_register_command(0x06, data[6:7])
-        else:
-            write_reg_cmd = self.adc_ops.unsafe_write_register_command(ADCReg.REG_ID.value, data)
-        start_cmd     = self.adc_ops.start_adc(ADCNum.ADC_1.value) # TODO: what does this do? how can it be batched?
-        read_cmd      = [ADCNum.ADC_1.value.read_cmd] + [255] * ADC_VOLTAGE_READ_LEN
-
-        # send command to trigger conversion & to read conversion data.
-        read_data = self.custom_adc_open_and_transfer(write_reg_cmd + start_cmd, conv_delay / 1000, read_cmd)
-
-        #with self.spi_open():
-        #    self.transfer(write_reg_cmd + start_cmd)
-        #    time.sleep(conv_delay / 1000) # 0.580
-        #    read_data = self.transfer(read_cmd)
-
-        # update ADC state (for state caching)
-        EdgePiADC.__state = new_edgepi_register_state
-
-        if (len(read_data) - 1) != ADC_VOLTAGE_READ_LEN:
-            raise VoltageReadError(
-                f"Voltage read failed: incorrect number of bytes ({len(read_data)}) retrieved"
-            )
-
-        voltage_code = read_data[2 : (2 + ADCNum.ADC_1.value.num_data_bytes)]
-        check_code = read_data[6]
-        check_crc(voltage_code, check_code)
-
-        calibs = self.__get_calibration_values(self.adc_calib_params[ADCNum.ADC_1], ADCNum.ADC_1) # 0.064
-
-        # convert from code to voltage
-        return DEV_code_to_voltage_single_ended(voltage_code, ADCNum.ADC_1.value, calibs) # 0.116
-
+    # TODO: ensure I understand every step of this function
+    # TODO: ensure I understand how this differs from the past version of this function
     def config_and_read_samples_batch(
         self,
+        adc_1_data_rate: ADC1DataRate,
         adc_1_analog_in_list: list[AnalogIn] = [],
-        adc_1_data_rate: ADC1DataRate = None,
-        adc_2_analog_in: AnalogIn = None,
-        adc_2_data_rate: ADC2DataRate = None,
-        conversion_mode: ConvMode = None
-    ):
+        differential_pairs: list[DiffMode] = [],
+    ) -> list:
+        """
+        This function sets the config, and reads from the provided ain and differential channels. Note that differential 
+        channels can overlap with ain and should not. This function does not support ADC 2, and changes the conversion 
+        mode to PULSE automatically.
+
+        Will reset any prior config made to the ADC. Does not work with RTD mode, and may override configs if RTD mode 
+        is active.
+
+        TODO: ensure that it's not possible to mess up the configuration?
+        """
+
+        if adc_1_analog_in_list == [] and differential_pairs == []:
+            raise Exception("Both inputs can't be empty")
+
+        if not isinstance(adc_1_data_rate.value, OpCode):
+            raise Exception("adc_1_data_rate invalid")
+
         adc_1_ch_list = []
         for adc_1_analog_in in adc_1_analog_in_list:
             adc_1_ch = self.__analog_in_to_adc_in_map.get(adc_1_analog_in)
             if adc_1_ch is None and adc_1_analog_in is not None:
                 raise TypeError(f"set_config: wrong type passed in adc_1_analog_in_list: {adc_1_analog_in}")
             adc_1_ch_list += [adc_1_ch]
-        
-        adc_2_ch = self.__analog_in_to_adc_in_map.get(adc_2_analog_in)
-        if adc_2_ch is None and adc_2_analog_in is not None:
-            raise TypeError(f"set_config: wrong type passed for adc_2_analog_in: {adc_2_analog_in}")
 
-        override_rtd_validation = False
-        
+        diff_update_list = [(diff_mode.value.mux_p, diff_mode.value.mux_n) for diff_mode in differential_pairs]
+
         # filter out self and None args
-        args = filter_dict_list_key_val(locals(), ["self", "adc_1_analog_in_list", "adc_2_analog_in"], [None])
+        opcodes = [adc_1_data_rate.value, ConvMode.PULSE.value]
 
-        # permit updates by rtd_mode() to turn RTD off when it's on, validate other updates
-        if not override_rtd_validation:
-            self.__validate_no_rtd_conflict(args) # 0.020
+        # get current register values
+        register_values = self.__get_register_map()
+        if len(register_values.values()) < 1:
+            raise ValueError("Number of reg_values must be at least 1")
+
+        def generate_config_and_read_commands(i:int, register_values, mux_p, mux_n):
+            # get opcodes for mapping multiplexers
+            ops_list = self.__get_channel_assign_opcodes(
+                adc_1_mux_p=mux_p,
+                adc_1_mux_n=mux_n,
+                override_rtd_validation=True,
+            )
+            ops_list += opcodes
+
+            # get codes to update register values
+            updated_reg_values = apply_opcodes(dict(register_values), ops_list)
+            register_values = { addx: entry["value"] for (addx, entry) in updated_reg_values.items() }
+
+            # TODO: ensure this is equivalent to before
+            data_rate = ADCState.get_state(register_values, ADCProperties.DATA_RATE_1).code
+            filter_mode = ADCState.get_state(register_values, ADCProperties.FILTER_MODE).code
+            conversion_delay = expected_initial_time_delay(
+                ADCNum.ADC_1, data_rate.value.op_code, filter_mode.value.op_code
+            ) / 1000
+
+            # TODO: understand the order of this & only compute the values that are actually needed; ie. only do the above once, 
+            # or even just skip it all since we know what our setting is supposed to be already...
+            data = [entry["value"] for entry in updated_reg_values.values()]
+            if i == 0:
+                # write entire state of updated reg values to ADC using a single write
+                write_reg_cmd = self.adc_ops.unsafe_write_register_command(ADCReg.REG_ID.value, data)
+            else:
+                # only write the register value
+                write_reg_cmd = self.adc_ops.unsafe_write_register_command(ADCReg.REG_INPMUX.value, data[6:7])
+
+            start_cmd = self.adc_ops.start_adc(ADCNum.ADC_1.value)
+            read_cmd  = [ADCNum.ADC_1.value.read_cmd] + [255] * ADC_VOLTAGE_READ_LEN # TODO: make this a function like the others
+
+            return (write_reg_cmd + start_cmd, conversion_delay, read_cmd), register_values
 
         # get instructions needed to send for each input
         command_tup_list = []
         for i, adc_1_ch in enumerate(adc_1_ch_list):
-            # get opcodes for mapping multiplexers
-            mux_args = {}
-            if "adc_1_ch" in args: mux_args["adc_1_mux_p"] = adc_1_ch
-            if "adc_2_ch" in args: mux_args["adc_2_mux_p"] = adc_2_ch
-            if "adc_1_mux_n" in args: mux_args["adc_1_mux_n"] = args["adc_1_mux_n"]
-            if "adc_2_mux_n" in args: mux_args["adc_2_mux_n"] = args["adc_2_mux_n"]
+            # AINCOM is the default, and implies this is not differential
+            command_tup, register_values = generate_config_and_read_commands(i, register_values, adc_1_ch, CH.AINCOM)
+            command_tup_list += [command_tup]
 
-            ops_list = self.__get_channel_assign_opcodes( # 0.184
-                **mux_args, override_rtd_validation=override_rtd_validation
-            )
-
-            # extract OpCode type args, since args may contain non-OpCode args
-            ops_list += [
-                entry.value
-                for entry in args.values()
-                if issubclass(entry.__class__, Enum) and isinstance(entry.value, OpCode)
-            ]
-
-            # get current register values
-            reg_values = self.__get_register_map() # 0.017
-            if len(reg_values.values()) < 1:
-                raise ValueError("Number of reg_values must be at least 1")
-
-            # get codes to update register values
-            updated_reg_values = apply_opcodes(dict(reg_values), ops_list) # 0.137
-            new_edgepi_register_state = { addx: entry["value"] for (addx, entry) in updated_reg_values.items() }
-
-            # TODO: ensure this is equivalent to before
-            data_rate = ADCState.get_state(new_edgepi_register_state, ADCProperties.DATA_RATE_1).code
-            filter_mode = ADCState.get_state(new_edgepi_register_state, ADCProperties.FILTER_MODE).code
-            conv_delay = expected_initial_time_delay(
-                ADCNum.ADC_1, data_rate.value.op_code, filter_mode.value.op_code
-            )
-
-            # write updated reg values to ADC using a single write.
-            data = [entry["value"] for entry in updated_reg_values.values()]
-            if i == 0:
-                write_reg_cmd = self.adc_ops.unsafe_write_register_command(ADCReg.REG_ID.value, data)
-            else:
-                write_reg_cmd = self.adc_ops.unsafe_write_register_command(0x06, data[6:7])
-
-            start_cmd = self.adc_ops.start_adc(ADCNum.ADC_1.value) # TODO: what does this do? how can it be batched?
-            read_cmd  = [ADCNum.ADC_1.value.read_cmd] + [255] * ADC_VOLTAGE_READ_LEN
-
-            command_tup_list += [(write_reg_cmd + start_cmd, conv_delay / 1000, read_cmd)]
+        for mux_p, mux_n in diff_update_list:
+            command_tup, register_values = generate_config_and_read_commands(-1, register_values, mux_p, mux_n)
+            command_tup_list += [command_tup]
 
         data_list = self.custom_adc_batch_open_and_transfer(command_tup_list)
 
-        # update ADC state (for state caching)
-        EdgePiADC.__state = new_edgepi_register_state
+        # update with final ADC state (for state caching)
+        EdgePiADC.__state = register_values
 
         voltage_list = []
-        for read_data in data_list:
+        for i, read_data in enumerate(data_list):
             if (len(read_data) - 1) != ADC_VOLTAGE_READ_LEN:
                 raise VoltageReadError(f"Voltage read failed: incorrect number of bytes ({len(read_data)}) retrieved")
 
@@ -1234,13 +1088,15 @@ class EdgePiADC(SPI):
             check_code = read_data[6]
             check_crc(voltage_code, check_code)
 
-            calibs = self.__get_calibration_values(self.adc_calib_params[ADCNum.ADC_1], ADCNum.ADC_1) # 0.064
+            calibs = self.__get_calibration_values(self.adc_calib_params[ADCNum.ADC_1], ADCNum.ADC_1)
 
             # convert from code to voltage
-            voltage_list += [DEV_code_to_voltage_single_ended(voltage_code, ADCNum.ADC_1.value, calibs)] # 0.116
+            if i < len(adc_1_ch_list):
+                voltage_list += [code_to_voltage_single_ended(voltage_code, ADCNum.ADC_1.value, calibs)]
+            else:
+                voltage_list += [code_to_voltage(voltage_code, ADCNum.ADC_1.value, calibs)]
 
         return voltage_list
-
 
     def get_state(self, override_cache: bool = False) -> ADCState:
         """
@@ -1256,5 +1112,4 @@ class EdgePiADC(SPI):
         if self.adc_state_cache is None or not self.enable_cache:
             reg_values = self.__get_register_map(override_cache)
             self.adc_state_cache = ADCState(reg_values)
-
         return self.adc_state_cache

--- a/src/edgepi/adc/edgepi_adc.py
+++ b/src/edgepi/adc/edgepi_adc.py
@@ -668,8 +668,7 @@ class EdgePiADC(SPI):
             validate_channels_allowed(channels, rtd_enabled)
 
         return generate_mux_opcodes(
-            ADCReg.REG_INPMUX, (adc_1_mux_p, adc_1_mux_n), 
-            ADCReg.REG_ADC2MUX, (adc_2_mux_p, adc_2_mux_n)
+            (adc_1_mux_p, adc_1_mux_n), (adc_2_mux_p, adc_2_mux_n)
         )
 
     def select_differential(self, adc: ADCNum, diff_mode: DiffMode):

--- a/src/edgepi/adc/edgepi_adc.py
+++ b/src/edgepi/adc/edgepi_adc.py
@@ -1004,7 +1004,7 @@ class EdgePiADC(SPI):
         is active.
 
         This function only supports ADC 1, and changes the conversion mode to PULSE automatically.
-        
+
         This function will not cache it's resulting register values. # TODO: change this?
         
         TODO: if even more performance is needed, continuous mode might only need to sleep for the first conversion!

--- a/src/edgepi/adc/edgepi_adc.py
+++ b/src/edgepi/adc/edgepi_adc.py
@@ -978,8 +978,8 @@ class EdgePiADC(SPI):
     def adc1_config_and_read_samples_batch(
         self,
         data_rate: ADC1DataRate,
-        analog_in_list: list[AnalogIn],
-        differential_pairs: list[DiffMode],
+        analog_in_list: list[AnalogIn] = None,
+        differential_pairs: list[DiffMode] = None,
     ) -> list:
         """
         This function sets the config, and rb
@@ -988,7 +988,10 @@ class EdgePiADC(SPI):
         Will reset any prior config made to the ADC. Does not work with RTD mode, and may override configs if RTD mode 
         is active.
         """
-
+        if analog_in_list is None:
+            analog_in_list = []
+        if differential_pairs is None:
+            differential_pairs = []
         if analog_in_list == [] and differential_pairs == []:
             raise ValueError("Both analog_in_list and differential_pairs can't be empty")
 

--- a/src/edgepi/adc/edgepi_adc.py
+++ b/src/edgepi/adc/edgepi_adc.py
@@ -47,6 +47,7 @@ from edgepi.utilities.utilities import filter_dict, filter_dict_list_key_val
 from edgepi.reg_helper.reg_helper import OpCode, apply_opcodes
 from edgepi.adc.adc_multiplexers import (
     generate_mux_opcodes,
+    DEV_generate_mux_opcodes,
     validate_channels_allowed,
 )
 from edgepi.adc.adc_conv_time import expected_initial_time_delay, expected_continuous_time_delay
@@ -102,7 +103,7 @@ class EdgePiADC(SPI):
         enable_cache: bool = False,
         rtd_sensor_resistance: float = None,
         rtd_sensor_resistance_variation: float = None
-        ):
+    ):
         """
         Args:
             `enable_cache` (bool): set to True to enable state-caching
@@ -116,6 +117,7 @@ class EdgePiADC(SPI):
         super().__init__(bus_num=6, dev_id=1)
         # declare instance vars before config call below
         self.enable_cache = enable_cache
+        self.adc_state_cache = None # TODO: add enable/disable mechanism
 
         # Load eeprom data and generate dictionary of calibration dataclass
         eeprom = EdgePiEEPROM()
@@ -126,6 +128,7 @@ class EdgePiADC(SPI):
 
         self.adc_ops = ADCCommands()
         self.gpio = EdgePiGPIO()
+
         # ADC always needs to be in CRC check mode. This also updates the internal __state.
         # If this call to __config is removed, replace with a call to get_register_map to
         # initialize __state.
@@ -133,6 +136,9 @@ class EdgePiADC(SPI):
         # TODO: adc reference should ba a config that customer passes depending on the range of
         # voltage they are measuring. To be changed later when range config is implemented
         # self.set_adc_reference(ADCReferenceSwitching.GND_SW1.value)
+
+        # uses gpio & checks the current state
+        self.rtd_state_cache = self.__is_rtd_on()
 
         # user updated rtd hardware constants
         self.rtd_sensor_resistance = (
@@ -248,6 +254,7 @@ class EdgePiADC(SPI):
         # pylint: disable=expression-not-assigned
         self.gpio.set_pin_state(RTDPins.RTD_EN.value) if enable else \
         self.gpio.clear_pin_state(RTDPins.RTD_EN.value)
+        self.rtd_state_cache = enable
 
     # TODO: To be deleted
     def set_adc_reference(self, reference_config: ADCReferenceSwitching = None):
@@ -457,7 +464,6 @@ class EdgePiADC(SPI):
         return code_to_voltage_single_ended(voltage_code, adc_num.value, calibs) if single_ended\
             else code_to_voltage(voltage_code, adc_num.value, calibs)
 
-
     def read_rtd_temperature(self):
         """
         Read RTD temperature continuously. Note, to obtain valid temperature values,
@@ -525,6 +531,25 @@ class EdgePiADC(SPI):
         _logger.debug(f" read_voltage: gain {calibs.gain}, offset {calibs.offset}")
         return code_to_voltage_single_ended(voltage_code, ADCNum.ADC_1.value, calibs) if \
             single_ended  else code_to_voltage(voltage_code, ADCNum.ADC_1.value, calibs)
+
+    # NOTE: for this function, we assume single-ended mode, and that pulse mode is enabled
+    def DEV_single_sample(self) -> float:
+        """
+        Trigger a single ADC1 voltage sampling event, when performing single channel reading or
+        differential reading. ADC1 must be in `PULSE` conversion mode before calling this method.
+        """
+        # send command to trigger conversion
+        self.start_conversions(ADCNum.ADC_1)
+
+        # send command to read conversion data.
+        status_code, voltage_code, _ = self.__voltage_read(ADCNum.ADC_1) # 0.524
+
+        # log STATUS byte
+        status = get_adc_status(status_code) # 0.828
+        calibs = self.__get_calibration_values(self.adc_calib_params[ADCNum.ADC_1], ADCNum.ADC_1) # 0.065
+
+        # convert from code to voltage
+        return code_to_voltage_single_ended(voltage_code, ADCNum.ADC_1.value, calibs) # 1.627
 
     def single_sample_rtd(self):
         """
@@ -610,9 +635,10 @@ class EdgePiADC(SPI):
             return True
         return False
 
+    # TODO: will this be updated when rtd is set to be on? will the state cache pick up hardware changes? probably not...
     def __get_rtd_state(self):
         """
-        Get RTD state this includes the corrent mode (on/off) and the adc type being used
+        Get RTD state this includes the current mode (on/off) and the adc type being used
         (adc1 or adc2).
         Returns:
             rtd_mode (dictionary): RTD mode dictionary {"name of config": op_codes}
@@ -664,16 +690,16 @@ class EdgePiADC(SPI):
         # allowed channels depend on RTD_EN status
         if not override_rtd_validation:
             channels = list(args.values())
-            rtd_enabled = self.__is_rtd_on()
+            rtd_enabled = self.rtd_state_cache
             validate_channels_allowed(channels, rtd_enabled)
 
-        adc_mux_updates = {
-            ADCReg.REG_INPMUX: (adc_1_mux_p, adc_1_mux_n),
-            ADCReg.REG_ADC2MUX: (adc_2_mux_p, adc_2_mux_n),
-        }
+        # NOTE: this is only commented so we can test caching the opcodes result (cannot hash dict)
+        #adc_mux_updates = {
+        #    ADCReg.REG_INPMUX: (adc_1_mux_p, adc_1_mux_n),
+        #    ADCReg.REG_ADC2MUX: (adc_2_mux_p, adc_2_mux_n),
+        #}
 
-        opcodes = generate_mux_opcodes(adc_mux_updates)
-
+        opcodes = DEV_generate_mux_opcodes(ADCReg.REG_INPMUX, (adc_1_mux_p, adc_1_mux_n), ADCReg.REG_ADC2MUX, (adc_2_mux_p, adc_2_mux_n))
         return opcodes
 
     def select_differential(self, adc: ADCNum, diff_mode: DiffMode):
@@ -703,7 +729,7 @@ class EdgePiADC(SPI):
         diff_update = mux_properties[adc]
         self.__config(**diff_update)
 
-    def  __validate_no_rtd_conflict(self, updates: dict):
+    def __validate_no_rtd_conflict(self, updates: dict):
         """
         Checks no RTD related properties are being updated if RTD mode is enabled
 
@@ -759,7 +785,6 @@ class EdgePiADC(SPI):
             (ADC1RtdConfig.ON.value if adc_num ==ADCNum.ADC_1 else ADC2RtdConfig.ON.value)
         return updates
 
-
     def __get_rtd_off_update_config(self, adc_num: ADCNum):
         """
         generate update config dictionary to send to the config method
@@ -772,6 +797,7 @@ class EdgePiADC(SPI):
         (ADC1RtdConfig.OFF.value if adc_num == ADCNum.ADC_1  else ADC2RtdConfig.OFF.value)
         return updates
 
+    # TODO: is this called by the edgepi portal when changes to the config shadow is made?
     def set_rtd(self, set_rtd: bool, adc_num: ADCNum = ADCNum.ADC_2):
         """
         Enable/Disable RTD with ADC type passed as arguments.
@@ -788,11 +814,11 @@ class EdgePiADC(SPI):
             # default setting. And get RTD_ON configuration values
             updates = self.__get_rtd_on_update_config(
                            mux_2 if adc_num == ADCNum.ADC_1 else mux_1, adc_num)
-            # enable RTD pin to re-route internal circuit
-            self.__set_rtd_pin(set_rtd)
         else:
             updates = self.__get_rtd_off_update_config(adc_num)
-            self.__set_rtd_pin(set_rtd)
+
+        # enable RTD pin to re-route internal circuit
+        self.__set_rtd_pin(set_rtd)
 
         self.__config(**updates, override_rtd_validation=True)
 
@@ -878,11 +904,11 @@ class EdgePiADC(SPI):
 
         # permit updates by rtd_mode() to turn RTD off when it's on, validate other updates
         if not override_rtd_validation:
-            self.__validate_no_rtd_conflict(args)
+            self.__validate_no_rtd_conflict(args) # 0.020
 
         # get opcodes for mapping multiplexers
-        mux_args = self.__extract_mux_args(args)
-        ops_list = self.__get_channel_assign_opcodes(
+        mux_args = self.__extract_mux_args(args) # 0.019
+        ops_list = self.__get_channel_assign_opcodes(  # 0.738
             **mux_args, override_rtd_validation=override_rtd_validation
         )
 
@@ -899,19 +925,19 @@ class EdgePiADC(SPI):
         _logger.debug(f"__config: register values before updates:\n{reg_values}")
 
         # get codes to update register values
-        updated_reg_values = apply_opcodes(dict(reg_values), ops_list)
+        updated_reg_values = apply_opcodes(dict(reg_values), ops_list) # 1.842
         _logger.debug(f"__config: register values after updates:\n{reg_values}")
 
         # write updated reg values to ADC using a single write.
         data = [entry["value"] for entry in updated_reg_values.values()]
-        self.__write_register(ADCReg.REG_ID, data)
+        self.__write_register(ADCReg.REG_ID, data) # 1.460
 
         # update ADC state (for state caching)
-        self.__update_cache_map(updated_reg_values)
+        self.__update_cache_map(updated_reg_values) # 0.053
 
         # validate updates were applied correctly
         if not override_updates_validation:
-            self.__validate_updates(updated_reg_values)
+            self.__validate_updates(updated_reg_values) # 0.059
 
         return updated_reg_values
 
@@ -989,5 +1015,9 @@ class EdgePiADC(SPI):
         Returns:
             ADCState: information about the current ADC hardware state
         """
-        reg_values = self.__get_register_map(override_cache)
-        return ADCState(reg_values)
+        # TODO: combine this cache with __get_register_map
+        if self.adc_state_cache is None or not self.enable_cache:
+            reg_values = self.__get_register_map(override_cache)
+            self.adc_state_cache = ADCState(reg_values)
+
+        return self.adc_state_cache

--- a/src/edgepi/eeprom/edgepi_eeprom.py
+++ b/src/edgepi/eeprom/edgepi_eeprom.py
@@ -158,7 +158,7 @@ class EdgePiEEPROM(I2CDevice):
                 time.sleep(0.01)
         return bytes(buff[2:buff_and_len])
 
-    def read_edgepi_data(self):
+    def read_edgepi_data(self) -> EepromDataClass:
         """
         Read Edgepi reserved memory space and populate dataclass
         Args:

--- a/src/edgepi/eeprom/edgepi_eeprom_data.py
+++ b/src/edgepi/eeprom/edgepi_eeprom_data.py
@@ -17,7 +17,7 @@ from edgepi.eeprom.protobuf_assets.eeprom_data_classes.eeprom_key_module import 
 
 @dataclass
 class EepromDataClass:
-    """EEPROM Dataclass"""
+    """Stores data read from the EdgePi's non-volatile EEPROM"""
     # pylint: disable=too-many-instance-attributes
     dac_calib_params: DACModule = None
     adc1_calib_params: ADCModule = None

--- a/src/edgepi/eeprom/protobuf_assets/eeprom_data_classes/eeprom_adc_module.py
+++ b/src/edgepi/eeprom/protobuf_assets/eeprom_data_classes/eeprom_adc_module.py
@@ -3,6 +3,23 @@ from dataclasses import dataclass
 from edgepi.calibration.calibration_constants import CalibParam
 from edgepi.eeprom.protobuf_assets.generated_pb2 import adc_module_pb2
 
+class AdcCalibParamKeys:
+    """Keys for the ADC Callibration Parameters dictionary"""
+    ADC_CH_1 = 0
+    ADC_CH_2 = 1
+    ADC_CH_3 = 2
+    ADC_CH_4 = 3
+
+    ADC_CH_5 = 4
+    ADC_CH_6 = 5
+    ADC_CH_7 = 6
+    ADC_CH_8 = 7
+
+    ADC_DIFF_1 = 8
+    ADC_DIFF_2 = 9
+    ADC_DIFF_3 = 10
+    ADC_DIFF_4 = 11
+
 @dataclass
 class ADCModule:
     """ADC Module Dataclass"""
@@ -104,17 +121,19 @@ class ADCModule:
     def extract_ch_dict(self):
         """create channel to calibration param dictionary"""
         ch_dict = {
-            0:self.adc_ch_1,
-            1:self.adc_ch_2,
-            2:self.adc_ch_3,
-            3:self.adc_ch_4,
-            4:self.adc_ch_5,
-            5:self.adc_ch_6,
-            6:self.adc_ch_7,
-            7:self.adc_ch_8,
-            8:self.adc_diff_1,
-            9:self.adc_diff_2,
-            10:self.adc_diff_3,
-            11:self.adc_diff_4,
+            AdcCalibParamKeys.ADC_CH_1: self.adc_ch_1,
+            AdcCalibParamKeys.ADC_CH_2: self.adc_ch_2,
+            AdcCalibParamKeys.ADC_CH_3: self.adc_ch_3,
+            AdcCalibParamKeys.ADC_CH_4: self.adc_ch_4,
+
+            AdcCalibParamKeys.ADC_CH_5: self.adc_ch_5,
+            AdcCalibParamKeys.ADC_CH_6: self.adc_ch_6,
+            AdcCalibParamKeys.ADC_CH_7: self.adc_ch_7,
+            AdcCalibParamKeys.ADC_CH_8: self.adc_ch_8,
+
+            AdcCalibParamKeys.ADC_DIFF_1: self.adc_diff_1,
+            AdcCalibParamKeys.ADC_DIFF_2: self.adc_diff_2,
+            AdcCalibParamKeys.ADC_DIFF_3: self.adc_diff_3,
+            AdcCalibParamKeys.ADC_DIFF_4: self.adc_diff_4,
         }
         return ch_dict

--- a/src/edgepi/peripherals/spi.py
+++ b/src/edgepi/peripherals/spi.py
@@ -72,31 +72,6 @@ class SpiDevice:
         out = self.spi.transfer(data)
         return out
 
-    def custom_adc_open_and_transfer(self, data1:list, delay:int, data2:list) -> list:
-        try:
-            SpiDevice.lock_spi[self.dev_id].acquire()
-            self.spi = SPI(
-                self.devpath,
-                self.mode,
-                self.max_speed,
-                self.bit_order,
-                self.bits_per_word,
-                self.extra_flags,
-            )
-            self.spi.transfer(data1)
-            time.sleep(delay)
-            result = self.spi.transfer(data2)
-
-        finally:
-            try:
-                self.spi.close()
-            except Exception as exc:
-                raise OSError(f"Failed to close {self.devpath}") from exc
-            finally:
-                SpiDevice.lock_spi[self.dev_id].release()
-
-        return result
-
     def custom_adc_batch_open_and_transfer(self, command_tup_list):
         result_list = []
 
@@ -112,7 +87,7 @@ class SpiDevice:
             )
             for data1, delay, data2 in command_tup_list:
                 self.spi.transfer(data1)
-                time.sleep(delay) # TODO: make sure this wait is absolutely neccesary or if other delays might be needed
+                time.sleep(delay)
                 result_list += [self.spi.transfer(data2)]
 
         finally:

--- a/src/edgepi/peripherals/spi.py
+++ b/src/edgepi/peripherals/spi.py
@@ -5,12 +5,13 @@ Classes:
     SpiDevice
 """
 #pylint:disable=too-many-instance-attributes
+from contextlib import contextmanager
 import logging
 import threading
-from contextlib import contextmanager
+import time
+
 from periphery import SPI
 
-import time
 
 _logger = logging.getLogger(__name__)
 

--- a/src/edgepi/peripherals/spi.py
+++ b/src/edgepi/peripherals/spi.py
@@ -72,7 +72,7 @@ class SpiDevice:
         out = self.spi.transfer(data)
         return out
 
-    def custom_adc_batch_open_and_transfer(self, command_tup_list):
+    def spi_apply_adc_commands(self, command_tup_list):
         result_list = []
 
         try:

--- a/src/edgepi/peripherals/spi.py
+++ b/src/edgepi/peripherals/spi.py
@@ -73,6 +73,15 @@ class SpiDevice:
         return out
 
     def spi_apply_adc_commands(self, command_tup_list):
+        """
+        This function applies a list of SPI commands for use in the ADC module,
+        such as sending & reading data.
+
+        Each "command tuple" in the list contains a command, a delay (often required!),
+        then another command.
+
+        See the `unsafe_write_register_command` for creating commands.
+        """
         result_list = []
 
         try:

--- a/src/edgepi/reg_helper/reg_helper.py
+++ b/src/edgepi/reg_helper/reg_helper.py
@@ -13,6 +13,7 @@ Functions:
     apply_opcode(OpCode, int)
 """
 
+from functools import cache
 
 from copy import deepcopy
 from dataclasses import dataclass
@@ -103,9 +104,9 @@ def apply_opcodes(register_values: dict, opcodes: list):
             "empty values received for 'register_values' or 'opcodes' args, opcodes not applied"
         )
         raise ValueError("register_values and opcodes args must both be non-empty")
-    _format_register_map(register_values)
+    _format_register_map(register_values) # 0.047
 
-    original_regs = deepcopy(register_values)
+    #original_regs = deepcopy(register_values)
 
     # apply each opcode to its corresponding register
     for opcode in opcodes:
@@ -113,14 +114,15 @@ def apply_opcodes(register_values: dict, opcodes: list):
         # if this opcode maps to a valid register address
         if register_entry is not None:
             # apply the opcode to the register
-            register_entry["value"] = _apply_opcode(register_entry["value"], opcode)
+            register_entry["value"] = _apply_opcode(register_entry["value"], opcode) # 0.606
             register_entry["is_changed"] = True
 
-    __validate_register_updates(original_regs, register_values)
+    # NOTE: disabling register update validation because there's no reason for us to suspect the other values would change? I'm not sure why this was done before.
+    #__validate_register_updates(original_regs, register_values)
 
     return register_values
 
-
+@cache
 def _apply_opcode(register_value: int, opcode: OpCode):
     """
     Generates an update code for a specific register by applying an opcode

--- a/src/edgepi/reg_helper/reg_helper.py
+++ b/src/edgepi/reg_helper/reg_helper.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from enum import Enum
 import logging
 
+from copy import deepcopy
 
 _logger = logging.getLogger(__name__)
 
@@ -103,7 +104,7 @@ def apply_opcodes(register_values: dict, opcodes: list):
         raise ValueError("register_values and opcodes args must both be non-empty")
     _format_register_map(register_values)
 
-    #original_regs = deepcopy(register_values)
+    original_regs = deepcopy(register_values)
 
     # apply each opcode to its corresponding register
     for opcode in opcodes:
@@ -117,7 +118,7 @@ def apply_opcodes(register_values: dict, opcodes: list):
     # NOTE: disabling register update validation because there's no reason for us to suspect the other
     # values would change? I'm not sure why this was done before.
     # This is also quite slow, and affects the performance significantly
-    #__validate_register_updates(original_regs, register_values)
+    __validate_register_updates(original_regs, register_values)
 
     return register_values
 

--- a/src/edgepi/reg_helper/reg_helper.py
+++ b/src/edgepi/reg_helper/reg_helper.py
@@ -97,8 +97,7 @@ def apply_opcodes(register_values: dict, opcodes: list):
     Raises:
         ValueError: if either register_values or opcodes is empty
     """
-    #print("register_values:")
-    #print(register_values)
+
     if len(register_values) < 1 or len(opcodes) < 1:
         _logger.error(
             "empty values received for 'register_values' or 'opcodes' args, opcodes not applied"
@@ -117,9 +116,9 @@ def apply_opcodes(register_values: dict, opcodes: list):
             register_entry["value"] = _apply_opcode(register_entry["value"], opcode)
             register_entry["is_changed"] = True
 
-    # NOTE: disabling register update validation because there's no reason for us to suspect the other
-    # values would change? I'm not sure why this was done before.
-    # The deepcopy which depends on this is quite slow & affects performance significantly
+    # There's no reason for us to suspect the other values would change?
+    # I'm not sure why this was done. The deepcopy which depends on this
+    # is quite slow (takes 1ms!)
     __validate_register_updates(original_regs, register_values)
 
     return register_values

--- a/src/edgepi/reg_helper/reg_helper.py
+++ b/src/edgepi/reg_helper/reg_helper.py
@@ -13,11 +13,10 @@ Functions:
     apply_opcode(OpCode, int)
 """
 
+from copy import deepcopy
 from dataclasses import dataclass
 from enum import Enum
 import logging
-
-from copy import deepcopy
 
 _logger = logging.getLogger(__name__)
 

--- a/src/edgepi/reg_helper/reg_helper.py
+++ b/src/edgepi/reg_helper/reg_helper.py
@@ -114,7 +114,7 @@ def apply_opcodes(register_values: dict, opcodes: list):
             register_entry["value"] = _apply_opcode(register_entry["value"], opcode)
             register_entry["is_changed"] = True
 
-    # NOTE: disabling register update validation because there's no reason for us to suspect the other 
+    # NOTE: disabling register update validation because there's no reason for us to suspect the other
     # values would change? I'm not sure why this was done before.
     # This is also quite slow, and affects the performance significantly
     #__validate_register_updates(original_regs, register_values)

--- a/src/edgepi/reg_helper/reg_helper.py
+++ b/src/edgepi/reg_helper/reg_helper.py
@@ -97,6 +97,8 @@ def apply_opcodes(register_values: dict, opcodes: list):
     Raises:
         ValueError: if either register_values or opcodes is empty
     """
+    #print("register_values:")
+    #print(register_values)
     if len(register_values) < 1 or len(opcodes) < 1:
         _logger.error(
             "empty values received for 'register_values' or 'opcodes' args, opcodes not applied"
@@ -117,10 +119,11 @@ def apply_opcodes(register_values: dict, opcodes: list):
 
     # NOTE: disabling register update validation because there's no reason for us to suspect the other
     # values would change? I'm not sure why this was done before.
-    # This is also quite slow, and affects the performance significantly
+    # The deepcopy which depends on this is quite slow & affects performance significantly
     __validate_register_updates(original_regs, register_values)
 
     return register_values
+
 
 def _apply_opcode(register_value: int, opcode: OpCode):
     """

--- a/src/edgepi/reg_helper/reg_helper.py
+++ b/src/edgepi/reg_helper/reg_helper.py
@@ -102,7 +102,7 @@ def apply_opcodes(register_values: dict, opcodes: list):
             "empty values received for 'register_values' or 'opcodes' args, opcodes not applied"
         )
         raise ValueError("register_values and opcodes args must both be non-empty")
-    _format_register_map(register_values) # 0.047
+    _format_register_map(register_values)
 
     #original_regs = deepcopy(register_values)
 
@@ -112,12 +112,12 @@ def apply_opcodes(register_values: dict, opcodes: list):
         # if this opcode maps to a valid register address
         if register_entry is not None:
             # apply the opcode to the register
-            register_entry["value"] = _apply_opcode(register_entry["value"], opcode) # 0.606
+            register_entry["value"] = _apply_opcode(register_entry["value"], opcode)
             register_entry["is_changed"] = True
 
     # NOTE: disabling register update validation because there's no reason for us to suspect the other 
     # values would change? I'm not sure why this was done before.
-    # This is also very slow, and affects the performance significantly
+    # This is also quite slow, and affects the performance significantly
     #__validate_register_updates(original_regs, register_values)
 
     return register_values

--- a/src/edgepi/reg_helper/reg_helper.py
+++ b/src/edgepi/reg_helper/reg_helper.py
@@ -13,7 +13,6 @@ Functions:
     apply_opcode(OpCode, int)
 """
 
-from copy import deepcopy
 from dataclasses import dataclass
 from enum import Enum
 import logging

--- a/src/edgepi/reg_helper/reg_helper.py
+++ b/src/edgepi/reg_helper/reg_helper.py
@@ -13,8 +13,6 @@ Functions:
     apply_opcode(OpCode, int)
 """
 
-from functools import cache
-
 from copy import deepcopy
 from dataclasses import dataclass
 from enum import Enum
@@ -117,12 +115,13 @@ def apply_opcodes(register_values: dict, opcodes: list):
             register_entry["value"] = _apply_opcode(register_entry["value"], opcode) # 0.606
             register_entry["is_changed"] = True
 
-    # NOTE: disabling register update validation because there's no reason for us to suspect the other values would change? I'm not sure why this was done before.
+    # NOTE: disabling register update validation because there's no reason for us to suspect the other 
+    # values would change? I'm not sure why this was done before.
+    # This is also very slow, and affects the performance significantly
     #__validate_register_updates(original_regs, register_values)
 
     return register_values
 
-@cache
 def _apply_opcode(register_value: int, opcode: OpCode):
     """
     Generates an update code for a specific register by applying an opcode

--- a/src/edgepi/utilities/utilities.py
+++ b/src/edgepi/utilities/utilities.py
@@ -42,7 +42,7 @@ def filter_dict_list_key_val(dictionary: dict, entry_key: list, entry_val:list) 
         key or value matches either the entry_key or entry_val, respectively.
     """
     filtered_args = {
-        key: value for (key, value) in dictionary.items() \
+        key: value for (key, value) in dictionary.items()
         if key not in entry_key and value not in entry_val
     }
     return filtered_args

--- a/src/edgepi/utilities/utilities.py
+++ b/src/edgepi/utilities/utilities.py
@@ -62,6 +62,6 @@ def bitstring_from_list(data: list[int]) -> BitArray:
     return BitArray(bytes(data))
 
 
-def combine_to_uint32(a:int, b:int, c:int, d:int) -> int:
+def combine_to_uint32(a: int, b: int, c: int, d: int) -> int:
     """simply packs 4 bytes into a uint32 (BE)"""
     return (a << 24) + (b << 16) + (c << 8) + d

--- a/src/edgepi/utilities/utilities.py
+++ b/src/edgepi/utilities/utilities.py
@@ -5,9 +5,7 @@
         bitstring_from_list(list)
 """
 
-
 from bitstring import BitArray
-
 
 def filter_dict(dictionary: dict, entry_key="", entry_val="") -> dict:
     """use for filtering an entry from a dictionary by key or value
@@ -62,3 +60,7 @@ def bitstring_from_list(data: list[int]) -> BitArray:
     """
     # bytes() will raise a ValueError if any items are not in the range [0, 255]
     return BitArray(bytes(data))
+
+
+def combine_to_uint32(a:int, b:int, c:int, d:int) -> int:
+    return (a << 24) + (b << 16) + (c << 8) + d

--- a/src/edgepi/utilities/utilities.py
+++ b/src/edgepi/utilities/utilities.py
@@ -63,4 +63,5 @@ def bitstring_from_list(data: list[int]) -> BitArray:
 
 
 def combine_to_uint32(a:int, b:int, c:int, d:int) -> int:
+    """simply packs 4 bytes into a uint32 (BE)"""
     return (a << 24) + (b << 16) + (c << 8) + d

--- a/src/test_edgepi/integration_tests/test_adc/test_adc.py
+++ b/src/test_edgepi/integration_tests/test_adc/test_adc.py
@@ -889,7 +889,7 @@ def test_adc_batch_voltage(out_list, channel_list, voltage, adc):
     # sample
     result_list = []
     for i in range(250):
-        result_list += adc.batch_read_samples_adc1(
+        result_list += adc.read_samples_adc1_batch(
             data_rate=ADC1DataRate.SPS_38400,
             analog_in_list=channel_list,
         )
@@ -925,7 +925,7 @@ def test_adc_batch_speed(channel_list, adc):
     # do samples
     result_list = []
     for _ in range(NUM_ITER):
-        result_list += adc.batch_read_samples_adc1(
+        result_list += adc.read_samples_adc1_batch(
             data_rate=ADC1DataRate.SPS_38400,
             analog_in_list=channel_list,
         )

--- a/src/test_edgepi/integration_tests/test_adc/test_adc.py
+++ b/src/test_edgepi/integration_tests/test_adc/test_adc.py
@@ -889,7 +889,7 @@ def test_adc_batch_voltage(out_list, channel_list, voltage, adc):
     # sample
     result_list = []
     for i in range(250):
-        result_list += adc.adc1_config_and_read_samples_batch(
+        result_list += adc.batch_config_and_read_samples_adc1(
             data_rate=ADC1DataRate.SPS_38400,
             analog_in_list=channel_list,
         )
@@ -925,7 +925,7 @@ def test_adc_batch_speed(channel_list, adc):
     # do samples
     result_list = []
     for _ in range(NUM_ITER):
-        result_list += adc.adc1_config_and_read_samples_batch(
+        result_list += adc.batch_config_and_read_samples_adc1(
             data_rate=ADC1DataRate.SPS_38400,
             analog_in_list=channel_list,
         )

--- a/src/test_edgepi/integration_tests/test_adc/test_adc.py
+++ b/src/test_edgepi/integration_tests/test_adc/test_adc.py
@@ -901,6 +901,9 @@ def test_adc_batch_voltage(out_list, channel_list, voltage, adc):
     edgepi_dac.reset()
     adc.reset()
 
+AVG_SPEED_TARGET_MS = 10
+NUM_ITER = 500
+
 @pytest.mark.parametrize(
     "channel_list",
     [
@@ -917,9 +920,6 @@ def test_adc_batch_speed(channel_list, adc):
     '''
     This is a speed test, making sure that all ADC inputs can be read at a rate of 100hz (10ms)
     '''
-    AVG_SPEED_TARGET_MS = 10
-    NUM_ITER = 500
-
     start = time.time()
 
     # do samples
@@ -931,7 +931,6 @@ def test_adc_batch_speed(channel_list, adc):
         )
 
     avg = 1000.0 * ((time.time() - start) / NUM_ITER)
-    # print(avg)
     assert avg <= AVG_SPEED_TARGET_MS
 
     # reset adc registers to pre-test values

--- a/src/test_edgepi/integration_tests/test_adc/test_adc.py
+++ b/src/test_edgepi/integration_tests/test_adc/test_adc.py
@@ -1,5 +1,7 @@
 """ Integration tests for EdgePi ADC module """
 
+import time
+import statistics
 import logging
 import pytest
 
@@ -19,8 +21,12 @@ from edgepi.adc.adc_constants import (
     DiffMode,
     RTDModes,
     ADC1PGA,
+    AnalogIn,
 )
 from edgepi.adc.edgepi_adc import EdgePiADC
+
+from edgepi.dac.edgepi_dac import EdgePiDAC
+from edgepi.dac.dac_constants import DACChannel
 
 _logger = logging.getLogger(__name__)
 
@@ -791,7 +797,6 @@ def test_voltage_individual(ch, adc):
     _logger.info(f"test_voltage_individual: voltage  = {out}")
     assert out != 0
 
-
 @pytest.mark.parametrize(
     "adc_num, ch",
     [
@@ -834,7 +839,6 @@ def test_voltage_continuous(adc_num, ch, adc):
     finally:
         adc.stop_conversions(adc_num)
 
-
 @pytest.mark.parametrize('adc_num, diff, mux_reg, mux_reg_val',
     [
         (ADCNum.ADC_1, DiffMode.DIFF_1, ADCReg.REG_INPMUX, 0x01),
@@ -865,3 +869,70 @@ def test_set_rtd(enable, rtd_mode, adc_num, expected, adc):
     adc.set_rtd(set_rtd=enable, adc_num=adc_num)
     assert adc.get_state().rtd_mode == rtd_mode
     assert adc.get_state().rtd_adc == expected
+
+@pytest.mark.parametrize(
+    "out_list, channel_list, voltage",
+    [
+        ([DACChannel.AOUT2], [AnalogIn.AIN2], 3.0),
+        ([DACChannel.AOUT3], [AnalogIn.AIN3], 2.0),
+        ([DACChannel.AOUT2, DACChannel.AOUT3], [AnalogIn.AIN2, AnalogIn.AIN3], 1.0),
+    ],
+)
+def test_adc_batch_voltage(out_list, channel_list, voltage, adc):
+    edgepi_dac = EdgePiDAC()
+    edgepi_dac.set_dac_gain(False)
+
+    # write voltage values
+    for out_channel in out_list:
+        edgepi_dac.write_voltage(out_channel, voltage)
+
+    # sample
+    result_list = []
+    for i in range(250):
+        result_list += adc.adc1_config_and_read_samples_batch(
+            data_rate=ADC1DataRate.SPS_38400,
+            analog_in_list=channel_list,
+        )
+
+    for i, _ in enumerate(channel_list):
+        avg = statistics.mean(result_list[i::len(channel_list)])
+        assert (voltage - 0.15) <= avg <= (voltage + 0.15)
+
+    edgepi_dac.reset()
+    adc.reset()
+
+@pytest.mark.parametrize(
+    "channel_list",
+    [
+        ([
+            AnalogIn.AIN2, AnalogIn.AIN3,
+        ]),
+        ([
+            AnalogIn.AIN1, AnalogIn.AIN2, AnalogIn.AIN3, AnalogIn.AIN4,
+            AnalogIn.AIN5, AnalogIn.AIN6, AnalogIn.AIN7, AnalogIn.AIN8,
+        ]),
+    ],
+)
+def test_adc_batch_speed(channel_list, adc):
+    '''
+    This is a speed test, making sure that all ADC inputs can be read at a rate of 100hz (10ms)
+    '''
+    AVG_SPEED_TARGET_MS = 10
+    NUM_ITER = 500
+
+    start = time.time()
+
+    # do samples
+    result_list = []
+    for _ in range(NUM_ITER):
+        result_list += adc.adc1_config_and_read_samples_batch(
+            data_rate=ADC1DataRate.SPS_38400,
+            analog_in_list=channel_list,
+        )
+
+    avg = 1000.0 * ((time.time() - start) / NUM_ITER)
+    # print(avg)
+    assert avg <= AVG_SPEED_TARGET_MS
+
+    # reset adc registers to pre-test values
+    adc.reset()

--- a/src/test_edgepi/integration_tests/test_adc/test_adc.py
+++ b/src/test_edgepi/integration_tests/test_adc/test_adc.py
@@ -889,7 +889,7 @@ def test_adc_batch_voltage(out_list, channel_list, voltage, adc):
     # sample
     result_list = []
     for i in range(250):
-        result_list += adc.batch_config_and_read_samples_adc1(
+        result_list += adc.batch_read_samples_adc1(
             data_rate=ADC1DataRate.SPS_38400,
             analog_in_list=channel_list,
         )
@@ -925,7 +925,7 @@ def test_adc_batch_speed(channel_list, adc):
     # do samples
     result_list = []
     for _ in range(NUM_ITER):
-        result_list += adc.batch_config_and_read_samples_adc1(
+        result_list += adc.batch_read_samples_adc1(
             data_rate=ADC1DataRate.SPS_38400,
             analog_in_list=channel_list,
         )

--- a/src/test_edgepi/integration_tests/test_eeprom/test_eeprom.py
+++ b/src/test_edgepi/integration_tests/test_eeprom/test_eeprom.py
@@ -60,7 +60,6 @@ def test__page_write_register(data, address, eeprom):
 
     finally:
         # Write the original data back
-        time.sleep(1)
         eeprom.write_edgepi_data(original_data)
 
 DUMMY_KEY = '-----BEGIN RSA PRIVATE KEY-----\nMIIEpQIBAAKCAQEAnwu+S/OI3Hl0BCNQASv0HU5Jc4KUT2X4/tLyk\
@@ -120,7 +119,6 @@ def test_write_edgepi_data(eeprom):
 
     finally:
         # Write the original data back
-        time.sleep(1)
         eeprom.write_edgepi_data(original_data)
 
 @pytest.mark.parametrize("bin_hash, error",
@@ -156,5 +154,4 @@ def test_reset_edgepi_memory(bin_hash, error, eeprom):
             assert written_data.cm4_part_number == default_data.cm4_part_number
     finally:
         # Reset to original data
-        time.sleep(1)
         eeprom.write_edgepi_data(original_data)

--- a/src/test_edgepi/integration_tests/test_eeprom/test_eeprom.py
+++ b/src/test_edgepi/integration_tests/test_eeprom/test_eeprom.py
@@ -60,6 +60,7 @@ def test__page_write_register(data, address, eeprom):
 
     finally:
         # Write the original data back
+        time.sleep(1)
         eeprom.write_edgepi_data(original_data)
 
 DUMMY_KEY = '-----BEGIN RSA PRIVATE KEY-----\nMIIEpQIBAAKCAQEAnwu+S/OI3Hl0BCNQASv0HU5Jc4KUT2X4/tLyk\
@@ -84,7 +85,6 @@ TmZ\n-----END RSA PRIVATE KEY-----\n'
 def test_write_edgepi_data(eeprom):
     if platform.node() != TEST_DEVICE_NAME:
         pytest.skip("won't run dangerous test on user device")
-
     original_data = eeprom.read_edgepi_data()
     try:
         for _ in range(10):
@@ -93,7 +93,6 @@ def test_write_edgepi_data(eeprom):
             res = ''.join(
                 random.choices(string.ascii_uppercase + string.digits, k=str_len)
             )
-
             # Modified data to write to memory
             modified_data = eeprom.read_edgepi_data()
             modified_data.config_key.certificate = DUMMY_KEY + res
@@ -104,7 +103,6 @@ def test_write_edgepi_data(eeprom):
             eeprom.write_edgepi_data(modified_data)
             # Read back the changed data
             modified_data = eeprom.read_edgepi_data()
-
             assert modified_data.dac_calib_params == original_data.dac_calib_params
             assert modified_data.adc1_calib_params == original_data.adc1_calib_params
             assert modified_data.adc2_calib_params == original_data.adc2_calib_params
@@ -122,6 +120,7 @@ def test_write_edgepi_data(eeprom):
 
     finally:
         # Write the original data back
+        time.sleep(1)
         eeprom.write_edgepi_data(original_data)
 
 @pytest.mark.parametrize("bin_hash, error",
@@ -157,4 +156,5 @@ def test_reset_edgepi_memory(bin_hash, error, eeprom):
             assert written_data.cm4_part_number == default_data.cm4_part_number
     finally:
         # Reset to original data
+        time.sleep(1)
         eeprom.write_edgepi_data(original_data)

--- a/src/test_edgepi/unit_tests/test_adc/test_adc_multiplexers.py
+++ b/src/test_edgepi/unit_tests/test_adc/test_adc_multiplexers.py
@@ -14,7 +14,7 @@ from edgepi.adc.adc_multiplexers import (
 
 
 @pytest.mark.parametrize(
-    "adc1_reg, adc1_mux, adc2_reg, adc2_mux, expected",
+    "adc1_mux, adc2_mux, expected",
     [
         (
             (None, None), (None, None),

--- a/src/test_edgepi/unit_tests/test_adc/test_adc_multiplexers.py
+++ b/src/test_edgepi/unit_tests/test_adc/test_adc_multiplexers.py
@@ -7,70 +7,43 @@ import pytest
 from edgepi.adc.adc_constants import ADCChannel as CH, ADCReg
 from edgepi.reg_helper.reg_helper import BitMask, OpCode
 from edgepi.adc.adc_multiplexers import (
-    generate_mux_opcodes,
+    generate_mux_opcode,
     ChannelNotAvailableError,
     validate_channels_allowed,
 )
 
 
 @pytest.mark.parametrize(
-    "adc1_mux, adc2_mux, expected",
+    "addx, adc1_mux, adc2_mux, expected",
     [
         (
-            (None, None), (None, None),
-            [],
+            ADCReg.REG_INPMUX,
+            CH.AIN1,
+            CH.AINCOM,
+            OpCode(0x1A, ADCReg.REG_INPMUX.value, BitMask.BYTE.value),
         ),
         (
-            (None, CH.AIN2), (None, None),
-            [],
+            ADCReg.REG_ADC2MUX,
+            CH.AIN5,
+            CH.AIN6,
+            OpCode(0x56, ADCReg.REG_ADC2MUX.value, BitMask.BYTE.value),
         ),
         (
-            (CH.AIN1, CH.AINCOM), (None, None),
-            [OpCode(0x1A, ADCReg.REG_INPMUX.value, BitMask.BYTE.value)],
+            ADCReg.REG_INPMUX,
+            CH.AIN1,
+            CH.AIN2,
+            OpCode(0x12, ADCReg.REG_INPMUX.value, BitMask.BYTE.value),
         ),
         (
-            (CH.AIN7, None), (None, None),
-            [],
-        ),
-        (
-            (None, CH.AIN5), (None, None),
-            [],
-        ),
-        (
-            (None, None), (CH.AIN5, None),
-            [],
-        ),
-        (
-            (None, None), (None, CH.AIN6),
-            [],
-        ),
-        (
-            (None, None), (CH.AIN5, CH.AIN6),
-            [OpCode(0x56, ADCReg.REG_ADC2MUX.value, BitMask.BYTE.value)],
-        ),
-        (
-            (CH.AIN1, None), (None, None),
-            [],
-        ),
-        (
-            (CH.AIN5, None), (None, CH.AIN6),
-            [],
-        ),
-        (
-            (None, CH.AIN5), (CH.AIN6, None),
-            [],
-        ),
-        (
-            (CH.AIN1, CH.AIN2), (CH.AIN3, CH.AIN4),
-            [
-                OpCode(0x12, ADCReg.REG_INPMUX.value, BitMask.BYTE.value),
-                OpCode(0x34, ADCReg.REG_ADC2MUX.value, BitMask.BYTE.value),
-            ],
+            ADCReg.REG_ADC2MUX,
+            CH.AIN3,
+            CH.AIN4,
+            OpCode(0x34, ADCReg.REG_ADC2MUX.value, BitMask.BYTE.value),
         ),
     ],
 )
-def test_generate_mux_opcodes(adc1_mux, adc2_mux, expected):
-    assert generate_mux_opcodes(adc1_mux, adc2_mux) == expected
+def test_generate_mux_opcode(adc1_mux, adc2_mux, expected):
+    assert generate_mux_opcode(adc1_mux, adc2_mux) == expected
 
 
 @pytest.mark.parametrize(

--- a/src/test_edgepi/unit_tests/test_adc/test_adc_multiplexers.py
+++ b/src/test_edgepi/unit_tests/test_adc/test_adc_multiplexers.py
@@ -42,8 +42,8 @@ from edgepi.adc.adc_multiplexers import (
         ),
     ],
 )
-def test_generate_mux_opcode(adc1_mux, adc2_mux, expected):
-    assert generate_mux_opcode(adc1_mux, adc2_mux) == expected
+def test_generate_mux_opcode(addx, adc1_mux, adc2_mux, expected):
+    assert generate_mux_opcode(addx, adc1_mux, adc2_mux) == expected
 
 
 @pytest.mark.parametrize(

--- a/src/test_edgepi/unit_tests/test_adc/test_adc_multiplexers.py
+++ b/src/test_edgepi/unit_tests/test_adc/test_adc_multiplexers.py
@@ -14,90 +14,54 @@ from edgepi.adc.adc_multiplexers import (
 
 
 @pytest.mark.parametrize(
-    "mux_updates, expected",
+    "adc1_reg, adc1_mux, adc2_reg, adc2_mux, expected",
     [
         (
-            {
-                ADCReg.REG_INPMUX: (None, None),
-                ADCReg.REG_ADC2MUX: (None, None),
-            },
+            ADCReg.REG_INPMUX, (None, None), ADCReg.REG_ADC2MUX, (None, None),
             [],
         ),
         (
-            {
-                ADCReg.REG_INPMUX: (None, CH.AIN2),
-                ADCReg.REG_ADC2MUX: (None, None),
-            },
+            ADCReg.REG_INPMUX, (None, CH.AIN2), ADCReg.REG_ADC2MUX, (None, None),
             [],
         ),
         (
-            {
-                ADCReg.REG_INPMUX: (CH.AIN1, CH.AINCOM),
-                ADCReg.REG_ADC2MUX: (None, None),
-            },
+            ADCReg.REG_INPMUX, (CH.AIN1, CH.AINCOM), ADCReg.REG_ADC2MUX, (None, None),
             [OpCode(0x1A, ADCReg.REG_INPMUX.value, BitMask.BYTE.value)],
         ),
         (
-            {
-                ADCReg.REG_INPMUX: (CH.AIN7, None),
-                ADCReg.REG_ADC2MUX: (None, None),
-            },
+            ADCReg.REG_INPMUX, (CH.AIN7, None), ADCReg.REG_ADC2MUX, (None, None),
             [],
         ),
         (
-            {
-                ADCReg.REG_INPMUX: (None, CH.AIN5),
-                ADCReg.REG_ADC2MUX: (None, None),
-            },
+            ADCReg.REG_INPMUX, (None, CH.AIN5), ADCReg.REG_ADC2MUX, (None, None),
             [],
         ),
         (
-            {
-                ADCReg.REG_INPMUX: (None, None),
-                ADCReg.REG_ADC2MUX: (CH.AIN5, None),
-            },
+            ADCReg.REG_INPMUX, (None, None), ADCReg.REG_ADC2MUX, (CH.AIN5, None),
             [],
         ),
         (
-            {
-                ADCReg.REG_INPMUX: (None, None),
-                ADCReg.REG_ADC2MUX: (None, CH.AIN6),
-            },
+            ADCReg.REG_INPMUX, (None, None), ADCReg.REG_ADC2MUX, (None, CH.AIN6),
             [],
         ),
         (
-            {
-                ADCReg.REG_INPMUX: (None, None),
-                ADCReg.REG_ADC2MUX: (CH.AIN5, CH.AIN6),
-            },
+            ADCReg.REG_INPMUX, (None, None), ADCReg.REG_ADC2MUX, (CH.AIN5, CH.AIN6),
             [OpCode(0x56, ADCReg.REG_ADC2MUX.value, BitMask.BYTE.value)],
         ),
         (
-            {
-                ADCReg.REG_INPMUX: (CH.AIN1, None),
-                ADCReg.REG_ADC2MUX: (None, None),
-            },
+            ADCReg.REG_INPMUX, (CH.AIN1, None), ADCReg.REG_ADC2MUX, (None, None),
             [],
         ),
         (
-            {
-                ADCReg.REG_INPMUX: (CH.AIN5, None),
-                ADCReg.REG_ADC2MUX: (None, CH.AIN6),
-            },
+            ADCReg.REG_INPMUX, (CH.AIN5, None), ADCReg.REG_ADC2MUX, (None, CH.AIN6),
             [],
         ),
         (
-            {
-                ADCReg.REG_INPMUX: (None, CH.AIN5),
-                ADCReg.REG_ADC2MUX: (CH.AIN6, None),
-            },
+            ADCReg.REG_INPMUX, (None, CH.AIN5), ADCReg.REG_ADC2MUX, (CH.AIN6, None),
             [],
         ),
         (
-            {
-                ADCReg.REG_INPMUX: (CH.AIN1, CH.AIN2),
-                ADCReg.REG_ADC2MUX: (CH.AIN3, CH.AIN4),
-            },
+            ADCReg.REG_INPMUX, (CH.AIN1, CH.AIN2), ADCReg.REG_ADC2MUX, (CH.AIN3, CH.AIN4),
             [
                 OpCode(0x12, ADCReg.REG_INPMUX.value, BitMask.BYTE.value),
                 OpCode(0x34, ADCReg.REG_ADC2MUX.value, BitMask.BYTE.value),
@@ -105,8 +69,8 @@ from edgepi.adc.adc_multiplexers import (
         ),
     ],
 )
-def test_generate_mux_opcodes(mux_updates, expected):
-    assert generate_mux_opcodes(mux_updates) == expected
+def test_generate_mux_opcodes(adc1_reg, adc1_mux, adc2_reg, adc2_mux, expected):
+    assert generate_mux_opcodes(adc1_reg, adc1_mux, adc2_reg, adc2_mux) == expected
 
 
 @pytest.mark.parametrize(

--- a/src/test_edgepi/unit_tests/test_adc/test_adc_multiplexers.py
+++ b/src/test_edgepi/unit_tests/test_adc/test_adc_multiplexers.py
@@ -17,51 +17,51 @@ from edgepi.adc.adc_multiplexers import (
     "adc1_reg, adc1_mux, adc2_reg, adc2_mux, expected",
     [
         (
-            ADCReg.REG_INPMUX, (None, None), ADCReg.REG_ADC2MUX, (None, None),
+            (None, None), (None, None),
             [],
         ),
         (
-            ADCReg.REG_INPMUX, (None, CH.AIN2), ADCReg.REG_ADC2MUX, (None, None),
+            (None, CH.AIN2), (None, None),
             [],
         ),
         (
-            ADCReg.REG_INPMUX, (CH.AIN1, CH.AINCOM), ADCReg.REG_ADC2MUX, (None, None),
+            (CH.AIN1, CH.AINCOM), (None, None),
             [OpCode(0x1A, ADCReg.REG_INPMUX.value, BitMask.BYTE.value)],
         ),
         (
-            ADCReg.REG_INPMUX, (CH.AIN7, None), ADCReg.REG_ADC2MUX, (None, None),
+            (CH.AIN7, None), (None, None),
             [],
         ),
         (
-            ADCReg.REG_INPMUX, (None, CH.AIN5), ADCReg.REG_ADC2MUX, (None, None),
+            (None, CH.AIN5), (None, None),
             [],
         ),
         (
-            ADCReg.REG_INPMUX, (None, None), ADCReg.REG_ADC2MUX, (CH.AIN5, None),
+            (None, None), (CH.AIN5, None),
             [],
         ),
         (
-            ADCReg.REG_INPMUX, (None, None), ADCReg.REG_ADC2MUX, (None, CH.AIN6),
+            (None, None), (None, CH.AIN6),
             [],
         ),
         (
-            ADCReg.REG_INPMUX, (None, None), ADCReg.REG_ADC2MUX, (CH.AIN5, CH.AIN6),
+            (None, None), (CH.AIN5, CH.AIN6),
             [OpCode(0x56, ADCReg.REG_ADC2MUX.value, BitMask.BYTE.value)],
         ),
         (
-            ADCReg.REG_INPMUX, (CH.AIN1, None), ADCReg.REG_ADC2MUX, (None, None),
+            (CH.AIN1, None), (None, None),
             [],
         ),
         (
-            ADCReg.REG_INPMUX, (CH.AIN5, None), ADCReg.REG_ADC2MUX, (None, CH.AIN6),
+            (CH.AIN5, None), (None, CH.AIN6),
             [],
         ),
         (
-            ADCReg.REG_INPMUX, (None, CH.AIN5), ADCReg.REG_ADC2MUX, (CH.AIN6, None),
+            (None, CH.AIN5), (CH.AIN6, None),
             [],
         ),
         (
-            ADCReg.REG_INPMUX, (CH.AIN1, CH.AIN2), ADCReg.REG_ADC2MUX, (CH.AIN3, CH.AIN4),
+            (CH.AIN1, CH.AIN2), (CH.AIN3, CH.AIN4),
             [
                 OpCode(0x12, ADCReg.REG_INPMUX.value, BitMask.BYTE.value),
                 OpCode(0x34, ADCReg.REG_ADC2MUX.value, BitMask.BYTE.value),
@@ -69,8 +69,8 @@ from edgepi.adc.adc_multiplexers import (
         ),
     ],
 )
-def test_generate_mux_opcodes(adc1_reg, adc1_mux, adc2_reg, adc2_mux, expected):
-    assert generate_mux_opcodes(adc1_reg, adc1_mux, adc2_reg, adc2_mux) == expected
+def test_generate_mux_opcodes(adc1_mux, adc2_mux, expected):
+    assert generate_mux_opcodes(adc1_mux, adc2_mux) == expected
 
 
 @pytest.mark.parametrize(

--- a/src/test_edgepi/unit_tests/test_adc/test_adc_voltage.py
+++ b/src/test_edgepi/unit_tests/test_adc/test_adc_voltage.py
@@ -95,7 +95,10 @@ def test__adc_voltage_to_input_voltage(voltage, gain, offset, result):
     ],
 )
 def test_code_to_voltage(code, adc_num, calibs, result):
-    assert pytest.approx(code_to_voltage(code, adc_num, calibs, single_ended=False),0.0001) == result
+    assert pytest.approx(
+        code_to_voltage(code, adc_num, calibs, single_ended=False),
+        0.0001,
+    ) == result
 
 @pytest.mark.parametrize(
     "code, adc_num, calibs, result",

--- a/src/test_edgepi/unit_tests/test_adc/test_adc_voltage.py
+++ b/src/test_edgepi/unit_tests/test_adc/test_adc_voltage.py
@@ -3,7 +3,6 @@
 import pytest
 
 from edgepi.calibration.calibration_constants import CalibParam
-from edgepi.utilities.utilities import bitstring_from_list
 from edgepi.adc.adc_constants import ADCNum
 from edgepi.adc.adc_voltage import (
     _code_to_input_voltage,

--- a/src/test_edgepi/unit_tests/test_adc/test_adc_voltage.py
+++ b/src/test_edgepi/unit_tests/test_adc/test_adc_voltage.py
@@ -26,8 +26,7 @@ OFFSET = 0
                          ([0x7F,0xFF,0xFF,0xFF], False),
                         ])
 def test_is_negative_voltage(code, result):
-    code_bits = bitstring_from_list(code)
-    assert _is_negative_voltage(code_bits) ==result
+    assert _is_negative_voltage(code) == result
 
 
 @pytest.mark.parametrize(

--- a/src/test_edgepi/unit_tests/test_adc/test_adc_voltage.py
+++ b/src/test_edgepi/unit_tests/test_adc/test_adc_voltage.py
@@ -9,7 +9,6 @@ from edgepi.adc.adc_voltage import (
     _is_negative_voltage,
     _adc_voltage_to_input_voltage,
     code_to_voltage,
-    code_to_voltage_single_ended,
     code_to_temperature,
 )
 
@@ -96,7 +95,7 @@ def test__adc_voltage_to_input_voltage(voltage, gain, offset, result):
     ],
 )
 def test_code_to_voltage(code, adc_num, calibs, result):
-    assert pytest.approx(code_to_voltage(code, adc_num, calibs),0.0001) == result
+    assert pytest.approx(code_to_voltage(code, adc_num, calibs, single_ended=False),0.0001) == result
 
 @pytest.mark.parametrize(
     "code, adc_num, calibs, result",
@@ -115,7 +114,7 @@ def test_code_to_voltage(code, adc_num, calibs, result):
     ],
 )
 def test_code_to_voltage_single_ended(code, adc_num, calibs, result):
-    assert pytest.approx(code_to_voltage_single_ended(code, adc_num, calibs),0.0001) == result
+    assert pytest.approx(code_to_voltage(code, adc_num, calibs, single_ended=True),0.0001) == result
 
 @pytest.mark.parametrize(
     "code, ref_resistance, temp_offset, rtd_conv_constant,rtd_gain,rtd_offset,adc_num,expected",

--- a/src/test_edgepi/unit_tests/test_adc/test_edgepi_adc.py
+++ b/src/test_edgepi/unit_tests/test_adc/test_edgepi_adc.py
@@ -1171,7 +1171,7 @@ def test__is_rtd_on(mocker, mock_value, result):
         ),
     ]
 )
-def test_adc1_config_and_read_samples_batch(
+def test_batch_config_and_read_samples_adc1(
     mocker,
     
     ain_list: list,
@@ -1204,7 +1204,7 @@ def test_adc1_config_and_read_samples_batch(
         return mock.DEFAULT
     spi_apply_commands.side_effect = check_commands
 
-    result_voltages = adc.adc1_config_and_read_samples_batch(
+    result_voltages = adc.batch_config_and_read_samples_adc1(
         data_rate=ADC1DataRate.SPS_38400,
         analog_in_list=ain_list,
         differential_pairs=diff_list,

--- a/src/test_edgepi/unit_tests/test_adc/test_edgepi_adc.py
+++ b/src/test_edgepi/unit_tests/test_adc/test_edgepi_adc.py
@@ -1004,7 +1004,7 @@ def test_get_calibration_values(mocker, reg_updates, adc_num, expected, err, adc
     mocker.patch("edgepi.adc.edgepi_adc.EdgePiADC.get_state", return_value=mock_state)
 
     with err:
-        out = adc._EdgePiADC__get_calibration_params(adc.adc_calib_params[adc_num], adc_num)
+        out = adc._EdgePiADC__get_calibration_params(adc_num)
         assert out == expected
 
 

--- a/src/test_edgepi/unit_tests/test_adc/test_edgepi_adc.py
+++ b/src/test_edgepi/unit_tests/test_adc/test_edgepi_adc.py
@@ -1203,7 +1203,7 @@ def test_batch_read_samples_adc1(
         return mock.DEFAULT
     spi_apply_commands.side_effect = check_commands
 
-    result_voltages = adc.batch_read_samples_adc1(
+    result_voltages = adc.read_samples_adc1_batch(
         data_rate=ADC1DataRate.SPS_38400,
         analog_in_list=ain_list,
         differential_pairs=diff_list,

--- a/src/test_edgepi/unit_tests/test_adc/test_edgepi_adc.py
+++ b/src/test_edgepi/unit_tests/test_adc/test_edgepi_adc.py
@@ -1004,7 +1004,7 @@ def test_get_calibration_values(mocker, reg_updates, adc_num, expected, err, adc
     mocker.patch("edgepi.adc.edgepi_adc.EdgePiADC.get_state", return_value=mock_state)
 
     with err:
-        out = adc._EdgePiADC__get_calibration_values(adc.adc_calib_params[adc_num], adc_num)
+        out = adc._EdgePiADC__get_calibration_params(adc.adc_calib_params[adc_num], adc_num)
         assert out == expected
 
 
@@ -1020,7 +1020,7 @@ def test_adc_voltage_read_conv_mode_validation(mocker, adc_to_read, validate, ad
     )
     mocker.patch("edgepi.adc.edgepi_adc.EdgePiADC._EdgePiADC__continuous_time_delay")
     mocker.patch("edgepi.adc.edgepi_adc.EdgePiADC._EdgePiADC__voltage_read", return_value=[0,0,0])
-    mocker.patch("edgepi.adc.edgepi_adc.EdgePiADC._EdgePiADC__get_calibration_values")
+    mocker.patch("edgepi.adc.edgepi_adc.EdgePiADC._EdgePiADC__get_calibration_params")
     mocker.patch("edgepi.adc.edgepi_adc.code_to_voltage")
     mocker.patch("edgepi.adc.edgepi_adc.get_adc_status")
     adc.read_voltage(adc_to_read)
@@ -1053,7 +1053,7 @@ def test_adc_voltage_read_mode(mocker, adc_to_read, ch, adc):
     mocker.patch("edgepi.adc.edgepi_adc.EdgePiADC._EdgePiADC__check_adc_1_conv_mode")
     mocker.patch("edgepi.adc.edgepi_adc.EdgePiADC._EdgePiADC__continuous_time_delay")
     mocker.patch("edgepi.adc.edgepi_adc.EdgePiADC._EdgePiADC__voltage_read", return_value=[0,0,0])
-    mocker.patch("edgepi.adc.edgepi_adc.EdgePiADC._EdgePiADC__get_calibration_values")
+    mocker.patch("edgepi.adc.edgepi_adc.EdgePiADC._EdgePiADC__get_calibration_params")
     _code_to_voltage = mocker.patch("edgepi.adc.edgepi_adc.code_to_voltage")
     mocker.patch("edgepi.adc.edgepi_adc.get_adc_status")
     adc.read_voltage(adc_to_read)
@@ -1087,7 +1087,7 @@ def test_adc_single_sample_mode(mocker, adc_to_read, ch, adc):
     )
     mocker.patch("edgepi.adc.edgepi_adc.EdgePiADC.start_conversions")
     mocker.patch("edgepi.adc.edgepi_adc.EdgePiADC._EdgePiADC__voltage_read", return_value=[0,0,0])
-    mocker.patch("edgepi.adc.edgepi_adc.EdgePiADC._EdgePiADC__get_calibration_values")
+    mocker.patch("edgepi.adc.edgepi_adc.EdgePiADC._EdgePiADC__get_calibration_params")
     _code_to_voltage = mocker.patch("edgepi.adc.edgepi_adc.code_to_voltage")
     mocker.patch("edgepi.adc.edgepi_adc.get_adc_status")
     adc.single_sample()

--- a/src/test_edgepi/unit_tests/test_adc/test_edgepi_adc.py
+++ b/src/test_edgepi/unit_tests/test_adc/test_edgepi_adc.py
@@ -1171,7 +1171,7 @@ def test__is_rtd_on(mocker, mock_value, result):
         ),
     ]
 )
-def test_batch_config_and_read_samples_adc1(
+def test_batch_read_samples_adc1(
     mocker,
     
     ain_list: list,
@@ -1204,7 +1204,7 @@ def test_batch_config_and_read_samples_adc1(
         return mock.DEFAULT
     spi_apply_commands.side_effect = check_commands
 
-    result_voltages = adc.batch_config_and_read_samples_adc1(
+    result_voltages = adc.batch_read_samples_adc1(
         data_rate=ADC1DataRate.SPS_38400,
         analog_in_list=ain_list,
         differential_pairs=diff_list,


### PR DESCRIPTION
Building on #423

Performance is improved by 19 times, from `105ms` per 8 ADC reads, to `5.5ms` per 8 ADC reads.

It's possible to improve the performance more than 160 hz for all 8 ADC, however 1/3 of all time is being spend sleeping, while another 1/3 is spent transferring data over SPI. It's unlikely to get faster than 200 hz. The speed improvements are due to bit optimizations, minimizing data sent over the channel, python optimizations, and batching of requests (minimize system calls opening & closing devices), all of which were found via profiling. For more info, see [this (private) page in the wiki](https://wiki.edgepi.com/en/prv/wip/gabe/high-freq-read-testing).

Main Changes
- add `batch_read_samples_adc1` with minimal calling of slow functions (`get_state()` is the evilest)
- refactor adc_commands functions to be static
- add `read_command_tuple` and `spi_apply_adc_commands` to efficiently read commands 
- misc refactoring to minimize complexity where worthwhile

TODOs
- [x] test that updates to the EdgePiADC.__state are being applied correctly
- [x] make sure that unit & integration tests are sufficient 